### PR TITLE
Bugfix/keypad identification

### DIFF
--- a/src/componentInterrogation.ts
+++ b/src/componentInterrogation.ts
@@ -74,7 +74,7 @@ export class ComponentInterrogation {
     const charac0 = component.componentCharacteristics?.[0];
     if (!charac0) return false;
     const dsTypes = charac0.dsTypesList;
-		return !!dsTypes?.find((q) => /DS_TYPES_KEY/gi.test(q));
+    return !!dsTypes?.find((q) => /DS_TYPES_KEY/gi.test(q));
   };
 
   static isIllumination = (component: EnvironmentComponent): boolean => {


### PR DESCRIPTION
The library is unable to identify the keypad on some platforms using strict checking against DS_TYPES_KEY, DS_TYPES_KEY_UP, or DS_TYPES_KEY_DOWN. This change makes keypad identification more flexible.