### PR TITLE
Remove deno-lint suppression comments

### DIFF
--- a/devtools/src/utils.ts
+++ b/devtools/src/utils.ts
@@ -53,8 +53,7 @@ export function isValidUrl(url: string): boolean {
 
 export function sanitizeInput(input: unknown): unknown {
   if (typeof input === "string") {
-    // deno-lint-ignore no-control-regex
-    return input.replace(/[\x00-\x1F\x7F]/g, "");
+    return input.replace(/\p{Cc}/gu, (ch) => (ch.charCodeAt(0) <= 0x1f || ch.charCodeAt(0) === 0x7f ? "" : ch));
   }
   if (Array.isArray(input)) {
     return input.map(sanitizeInput);

--- a/devtools/src/websocket.ts
+++ b/devtools/src/websocket.ts
@@ -14,8 +14,7 @@ export class WebSocketManager {
   private reconnectTimer: number | null = null;
   private isClosing = false;
   private messageBuffer: unknown[] = [];
-  // deno-lint-ignore ban-types
-  private eventHandlers: Map<keyof WebSocketManagerEvents, Set<Function>> = new Map();
+  private eventHandlers: Map<keyof WebSocketManagerEvents, Set<(...args: never[]) => void>> = new Map();
 
   constructor(private options: ConnectionOptions) {
     this.options.reconnectInterval = options.reconnectInterval ?? 2000;
@@ -48,7 +47,7 @@ export class WebSocketManager {
     if (handlers) {
       for (const handler of handlers) {
         try {
-          handler(...args);
+          (handler as (...args: unknown[]) => void)(...args);
         }
         catch (error) {
           console.error(`Error in event handler for ${event}:`, error);

--- a/src/connection.test.ts
+++ b/src/connection.test.ts
@@ -4,7 +4,7 @@ import { delay } from "@std/async/delay";
 import { Connection, global } from "./connection.ts";
 import { AuthenticationError } from "./models/Errors.ts";
 import { PlatformResponseError } from "./models/platformResponseError.ts";
-import { MessageCodes, PlatformDirectives } from "cuss2-typescript-models";
+import { type ApplicationData, MessageCodes, PlatformDirectives } from "cuss2-typescript-models";
 
 // Mock for the WebSocket class
 class MockWebSocket {
@@ -136,8 +136,7 @@ Deno.test(
     let authenticatingEmitted = false;
     let authenticatingAttempt = 0;
     let authenticatedEmitted = false;
-    // deno-lint-ignore no-explicit-any
-    let authenticatedData: any = null;
+    let authenticatedData!: { access_token: string; expires_in: number; token_type: string };
 
     global.fetch = (url: string | URL | Request, options?: RequestInit) => {
       fetchCalled = true;
@@ -182,7 +181,7 @@ Deno.test(
 
     connection.on("authenticated", (data) => {
       authenticatedEmitted = true;
-      authenticatedData = data;
+      authenticatedData = data as unknown as typeof authenticatedData;
     });
 
     // @ts-ignore - Accessing private method for testing
@@ -1532,8 +1531,7 @@ Deno.test("waitFor should reject when close event is emitted before target event
 Deno.test(
   "Connection flow should emit events in correct order",
   mockGlobal(async () => {
-    // deno-lint-ignore no-explicit-any
-    const events: { event: string; data?: any }[] = [];
+    const events: { event: string; data?: unknown }[] = [];
     let authAttempts = 0;
     let connectAttempts = 0;
 
@@ -1591,8 +1589,7 @@ Deno.test(
     // Verify authenticated event has token
     const authenticatedEvent = events.find((e) => e.event === "authenticated");
     assertExists(authenticatedEvent?.data);
-    // deno-lint-ignore no-explicit-any
-    assertExists((authenticatedEvent?.data as any).access_token);
+    assertExists((authenticatedEvent?.data as { access_token?: unknown }).access_token);
 
     // Verify connecting event has attempt number
     const connectingEvent = events.find((e) => e.event === "connecting");
@@ -1723,8 +1720,7 @@ Deno.test(
         directive: PlatformDirectives.PLATFORM_COMPONENTS,
       },
       payload: {},
-      // deno-lint-ignore no-explicit-any
-    } as any);
+    } as unknown as ApplicationData);
 
     // Wait a bit for the message to be sent
     await delay(10);


### PR DESCRIPTION
Removes 6 `deno-lint-ignore` comments:

- `devtools/utils.ts`: the control-character regex `[\x00-\x1F\x7F]` → `/\p{Cc}/gu` with a callback that removes exactly C0+DEL and preserves C1 (behavior-identical; property escape avoids `no-control-regex`).
- `devtools/websocket.ts`: `Set<Function>` (`ban-types`) → `Set<(...args: never[]) => void>` plus a typed cast at the emit call site.
- `connection.test.ts` (x4): definite-assignment for a closure-captured var, `unknown` on an events array, and typed casts (including `as unknown as ApplicationData`) replacing `as any`.

Intentionally left: the vendored `vendor/node-events-fixed.ts` (`deno-lint-ignore-file`) — third-party code.

`deno lint` clean, connection tests 34 pass, typecheck adds 0 new errors (8 pre-existing mock-typing errors unchanged).
