### PR TITLE
Fix authenticated event payload type

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -16,7 +16,7 @@ interface ConnectionEvents {
   open: [];
   authenticating: [number];
   connecting: [number];
-  authenticated: [typeof Connection.prototype._auth];
+  authenticated: [AuthResponse];
   messageError: [unknown];
   socketError: [unknown];
   authenticationError: [AuthenticationError];


### PR DESCRIPTION
### Bug

`ConnectionEvents.authenticated` was declared as `[typeof Connection.prototype._auth]` — the type of the **request credentials** (`{ url, client_id, client_secret }`). But the `authenticated` event is emitted at `connection.ts:160-165` with the **token response** (`{ access_token, expires_in, token_type }`). So the compile-time event contract did not match the runtime payload; consumers got a wrong type and had to cast around it.

### Fix

Point the event at the existing, already-imported `AuthResponse` model (`./models/authResponse.ts`), which is exactly `{ access_token: string; expires_in: number; token_type: string }` — the real emitted shape. One-line change; no new type, no runtime change.

Surfaced by an independent review of the deno-lint cleanup (cuss2-ts #52), whose test worked around this with an `as unknown as` cast that can be dropped once both land.

`deno lint` clean; 0 new type errors (7 pre-existing setTimeout/Timeout mock-typing errors unchanged); connection tests 34/34 pass.
