### PR TITLE
Convert @ts-ignore to @ts-expect-error; drop dead suppressions

### DIFF
--- a/devtools/src/websocket.ts
+++ b/devtools/src/websocket.ts
@@ -84,7 +84,7 @@ export class WebSocketManager {
         options = { headers: { Origin: baseURL } };
       }
 
-      // @ts-ignore - ws library accepts options as third parameter, browser ignores extra params
+      // @ts-expect-error - ws library accepts options as third parameter, browser ignores extra params
       this.ws = new globalThis.WebSocket(url.toString(), undefined, options);
 
       this.ws.onopen = () => {

--- a/devtools/src/ws.ts
+++ b/devtools/src/ws.ts
@@ -1,5 +1,4 @@
 // WebSocket polyfill for Deno (browsers have native WebSocket)
-// @ts-ignore - Deno.env check
 if (typeof Deno !== "undefined" && Deno.env) {
   // Running in Deno, need to import ws
   // top-level await not allowed in modules, so wrap in IIFE

--- a/src/WebSocket.ts
+++ b/src/WebSocket.ts
@@ -1,5 +1,4 @@
 // WebSocket polyfill for Deno (browsers have native WebSocket)
-// @ts-ignore - Deno.env check
 if (typeof Deno !== "undefined" && Deno.env) {
   // Running in Deno, need to import ws
   // top-level await not allowed in modules, so wrap in IIFE

--- a/src/component-status-updates.test.ts
+++ b/src/component-status-updates.test.ts
@@ -22,7 +22,7 @@ Deno.test("Component status updates - should NOT update status on ENABLE command
   const component = new BarcodeReader(componentData, cuss2);
 
   // Set initial status
-  // @ts-ignore - accessing private property for testing
+  // @ts-expect-error - accessing private property for testing
   component._status = MessageCodes.OK;
 
   // Create spy for statusChange event
@@ -55,7 +55,7 @@ Deno.test("Component status updates - should NOT update status on DISABLE comman
   const component = new BarcodeReader(componentData, cuss2);
 
   // Set initial status
-  // @ts-ignore - accessing private property for testing
+  // @ts-expect-error - accessing private property for testing
   component._status = MessageCodes.OK;
 
   const statusChangeSpy = spy();
@@ -86,7 +86,7 @@ Deno.test("Component status updates - should NOT update status on SETUP command 
   const componentData = mockDevice.createBarcodeReader(100);
   const component = new BarcodeReader(componentData, cuss2);
 
-  // @ts-ignore - accessing private property for testing
+  // @ts-expect-error - accessing private property for testing
   component._status = MessageCodes.OK;
 
   const statusChangeSpy = spy();
@@ -116,7 +116,7 @@ Deno.test("Component status updates - should NOT update status on SEND command r
   const componentData = mockDevice.createBarcodeReader(100);
   const component = new BarcodeReader(componentData, cuss2);
 
-  // @ts-ignore - accessing private property for testing
+  // @ts-expect-error - accessing private property for testing
   component._status = MessageCodes.OK;
 
   const statusChangeSpy = spy();
@@ -146,7 +146,7 @@ Deno.test("Component status updates - SHOULD update status on QUERY response", (
   const componentData = mockDevice.createBarcodeReader(100);
   const component = new BarcodeReader(componentData, cuss2);
 
-  // @ts-ignore - accessing private property for testing
+  // @ts-expect-error - accessing private property for testing
   component._status = MessageCodes.OK;
 
   const statusChangeSpy = spy();
@@ -181,7 +181,7 @@ Deno.test("Component status updates - SHOULD update status on unsolicited messag
   const componentData = mockDevice.createBarcodeReader(100);
   const component = new BarcodeReader(componentData, cuss2);
 
-  // @ts-ignore - accessing private property for testing
+  // @ts-expect-error - accessing private property for testing
   component._status = MessageCodes.OK;
 
   const statusChangeSpy = spy();
@@ -212,7 +212,7 @@ Deno.test("Component status updates - component state changes should still work 
   const componentData = mockDevice.createBarcodeReader(100);
   const component = new BarcodeReader(componentData, cuss2);
 
-  // @ts-ignore - accessing private property for testing
+  // @ts-expect-error - accessing private property for testing
   component._componentState = ComponentState.READY;
 
   const readyStateChangeSpy = spy();
@@ -244,7 +244,7 @@ Deno.test("Component status updates - multiple unsolicited messages should updat
   const componentData = mockDevice.createBarcodeReader(100);
   const component = new BarcodeReader(componentData, cuss2);
 
-  // @ts-ignore - accessing private property for testing
+  // @ts-expect-error - accessing private property for testing
   component._status = MessageCodes.OK;
 
   const statusChangeSpy = spy();

--- a/src/connection-url.test.ts
+++ b/src/connection-url.test.ts
@@ -64,7 +64,6 @@ Deno.test("Connection URL handling - extracts base URL correctly", () => {
     );
 
     // Access private property for testing
-    // @ts-ignore: Accessing private _auth property to verify token URL generation
     const actualTokenUrl = connection._auth.url;
 
     assertEquals(
@@ -86,7 +85,6 @@ Deno.test("Connection URL handling - respects explicit token URL", () => {
   );
 
   // Access private property for testing
-  // @ts-ignore: Accessing private _auth property to verify token URL generation
   const actualTokenUrl = connection._auth.url;
 
   assertEquals(
@@ -129,7 +127,6 @@ Deno.test("Connection URL handling - WebSocket URL construction", () => {
     );
 
     // Access private property for testing
-    // @ts-ignore: Accessing private _socketURL property to verify WebSocket URL generation
     const actualWsUrl = connection._socketURL;
 
     assertEquals(

--- a/src/connection.test.ts
+++ b/src/connection.test.ts
@@ -86,7 +86,6 @@ function mockGlobal(fn: () => Promise<unknown>): () => Promise<void> {
     }
     finally {
       // Restore original WebSocket
-      // @ts-ignore - restore for tests
       globalThis.WebSocket = originalWebSocket;
       global.fetch = globalThis.fetch;
       global.setTimeout = globalThis.setTimeout.bind(globalThis);
@@ -106,7 +105,7 @@ function mockWebSocket(action?: (ws: MockWebSocket) => (() => void) | undefined)
   }
   creator.prototype = MockWebSocket.prototype;
 
-  //@ts-ignore - Mock WebSocket for testing
+  //@ts-expect-error - Mock WebSocket for testing
   globalThis.WebSocket = creator;
   return mockWs;
 }
@@ -185,7 +184,7 @@ Deno.test(
       authenticatedData = data;
     });
 
-    // @ts-ignore - Accessing private method for testing
+    // @ts-expect-error - Accessing private method for testing
     const result = await connection.authorize();
 
     assertEquals(fetchCalled, true);
@@ -219,7 +218,7 @@ Deno.test(
     // Verify that calling the method throws the expected error
     await assertRejects(
       async () => {
-        // @ts-ignore - Accessing private method for testing
+        // @ts-expect-error - Accessing private method for testing
         await connection.authorize();
       },
       AuthenticationError,
@@ -266,7 +265,7 @@ Deno.test(
       authenticatingEvents.push(attempt);
     });
 
-    // @ts-ignore - Accessing private method for testing
+    // @ts-expect-error - Accessing private method for testing
     const result = await connection.authorize();
 
     assertEquals(fetchCallCount, 3);
@@ -285,9 +284,7 @@ Deno.test("Connection constructor should set URLs correctly", () => {
   );
 
   // Check that internal state is set correctly - now extracts origin only
-  // @ts-ignore - Accessing private property for testing
   assertEquals(connection._baseURL, "https://example.com");
-  // @ts-ignore - Accessing private property for testing
   assertEquals(connection._socketURL, "wss://example.com/api/?param=value");
 
   // Test with WebSocket URL - base URL extracts origin only
@@ -299,10 +296,8 @@ Deno.test("Connection constructor should set URLs correctly", () => {
     testTokenUrl,
   );
 
-  // @ts-ignore - Accessing private property for testing
   // Base URL should extract origin only
   assertEquals(wsConnection._baseURL, "ws://example.com");
-  // @ts-ignore - Accessing private property for testing
   assertEquals(wsConnection._socketURL, "ws://example.com/api/");
   // Note: testTokenUrl is provided, so OAuth URL uses the provided token URL
 
@@ -315,10 +310,8 @@ Deno.test("Connection constructor should set URLs correctly", () => {
     testTokenUrl,
   );
 
-  // @ts-ignore - Accessing private property for testing
   // Base URL should extract origin only
   assertEquals(wssConnection._baseURL, "wss://example.com");
-  // @ts-ignore - Accessing private property for testing
   assertEquals(wssConnection._socketURL, "wss://example.com/api/");
 });
 
@@ -331,7 +324,6 @@ Deno.test("OAuth URL should always use HTTP/HTTPS protocol", () => {
     testDeviceId,
     undefined, // No token URL provided
   );
-  // @ts-ignore - Accessing private property for testing
   assertEquals(wsConnectionNoToken._auth.url, "http://example.com/oauth/token");
 
   // Test with wss:// base URL and no explicit token URL - extracts origin only
@@ -342,7 +334,6 @@ Deno.test("OAuth URL should always use HTTP/HTTPS protocol", () => {
     testDeviceId,
     undefined, // No token URL provided
   );
-  // @ts-ignore - Accessing private property for testing
   assertEquals(wssConnectionNoToken._auth.url, "https://example.com/oauth/token");
 
   // Test with ws:// token URL explicitly provided
@@ -353,7 +344,6 @@ Deno.test("OAuth URL should always use HTTP/HTTPS protocol", () => {
     testDeviceId,
     "ws://auth.example.com/token", // Explicitly provided ws:// token URL
   );
-  // @ts-ignore - Accessing private property for testing
   assertEquals(wsConnectionWithWsToken._auth.url, "http://auth.example.com/token");
 
   // Test with wss:// token URL explicitly provided
@@ -364,7 +354,6 @@ Deno.test("OAuth URL should always use HTTP/HTTPS protocol", () => {
     testDeviceId,
     "wss://auth.example.com/token", // Explicitly provided wss:// token URL
   );
-  // @ts-ignore - Accessing private property for testing
   assertEquals(wssConnectionWithWssToken._auth.url, "https://auth.example.com/token");
 });
 
@@ -399,7 +388,7 @@ Deno.test(
       testTokenUrl,
     );
 
-    // @ts-ignore - Accessing private method for testing
+    // @ts-expect-error - Accessing private method for testing
     await connection._authenticateAndQueueTokenRefresh();
 
     assertEquals(connection.access_token, testToken);
@@ -407,11 +396,8 @@ Deno.test(
     assertEquals(timeoutDuration, 3599000); // (3600 - 1) * 1000
     assertExists(timeoutCallback);
 
-    // @ts-ignore - Accessing private property for testing
     assertEquals(connection._auth.url, testTokenUrl);
-    // @ts-ignore - Accessing private property for testing
     assertEquals(connection._auth.client_id, testClientId);
-    // @ts-ignore - Accessing private property for testing
     assertEquals(connection._auth.client_secret, testClientSecret);
   }),
 );
@@ -440,7 +426,7 @@ Deno.test(
     });
 
     // Call the method - it should not throw but emit an event
-    // @ts-ignore - Accessing private method for testing
+    // @ts-expect-error - Accessing private method for testing
     await connection._authenticateAndQueueTokenRefresh();
 
     // Verify the authenticationError event was emitted
@@ -475,7 +461,7 @@ Deno.test(
       testTokenUrl,
     );
 
-    // @ts-ignore - Accessing private method for testing
+    // @ts-expect-error - Accessing private method for testing
     await connection._authenticateAndQueueTokenRefresh();
 
     // Verify fetch was called
@@ -485,7 +471,6 @@ Deno.test(
     assertEquals(connection.access_token, "short-lived-token");
 
     // Verify no timeout is set due to expires_in being 0
-    // @ts-ignore - Accessing private property for testing
     assertEquals(connection._refresher, null);
   }),
 );
@@ -524,10 +509,9 @@ Deno.test(
       testTokenUrl,
     );
 
-    // @ts-ignore - Accessing private property for testing
     connection._refresher = mockTimeoutId as unknown as ReturnType<typeof setTimeout>;
 
-    // @ts-ignore - Accessing private method for testing
+    // @ts-expect-error - Accessing private method for testing
     await connection._authenticateAndQueueTokenRefresh();
 
     assertEquals(timeoutCleared, true);
@@ -573,7 +557,7 @@ Deno.test(
     // Wait for authentication and websocket creation
     await connection.waitFor("open");
 
-    // @ts-ignore - Accessing private property for testing
+    // @ts-expect-error - Accessing private property for testing
     assertEquals(connection._socket, mockWs);
     assertEquals(authenticateCalled, true);
     assertEquals(webSocketConstructorCalled, true);
@@ -640,7 +624,6 @@ Deno.test(
 
     assertEquals(connection.isOpen, true);
 
-    // @ts-ignore - Accessing private method for testing
     connection._createWebSocketAndAttachEventHandlers();
     // Give it a moment to check isOpen
     await delay(20);
@@ -667,17 +650,16 @@ Deno.test(
     // Track emitted events
     const emittedEvents: { event: string; data: unknown }[] = [];
 
-    // @ts-ignore - Event types are not properly defined for testing
     connection.on("message", (data) => {
       emittedEvents.push({ event: "message", data });
     });
 
-    // @ts-ignore - Event types are not properly defined for testing
+    // @ts-expect-error - Event types are not properly defined for testing
     connection.on("ping", (data) => {
       emittedEvents.push({ event: "ping", data });
     });
 
-    // @ts-ignore - Event types are not properly defined for testing
+    // @ts-expect-error - Event types are not properly defined for testing
     connection.on("ack", (data) => {
       emittedEvents.push({ event: "ack", data });
     });
@@ -782,7 +764,6 @@ Deno.test(
     let closeEventFired = false;
     let closeEventObj: CloseEvent | undefined;
 
-    // @ts-ignore - Event types are not properly defined for testing
     connection.once("close", (event) => {
       closeEventFired = true;
       closeEventObj = event;
@@ -871,7 +852,6 @@ Deno.test(
     // Authentication error occurs and is now surfaced via socketError
     assertEquals(authErrorOccurred, false); // Error is caught by our error handler
     assertEquals(errorEventEmitted, true); // Error event is now emitted
-    // @ts-ignore - Accessing private property for testing
     assertEquals(connection._socket, undefined); // Socket never created
     assertEquals(connection.access_token, ""); // Token never set
 
@@ -897,7 +877,6 @@ Deno.test("send should add missing oauthToken and deviceID to data", async () =>
   await connection.waitFor("open");
 
   // Create test data without oauthToken and deviceID
-  // @ts-ignore - Using simplified test data structure
   const testData = {
     meta: {
       requestID: "test-request-id",
@@ -906,7 +885,7 @@ Deno.test("send should add missing oauthToken and deviceID to data", async () =>
     payload: { test: true },
   };
 
-  // @ts-ignore - Testing with simplified data structure
+  // @ts-expect-error - Testing with simplified data structure
   connection.send(testData);
 
   // Verify data was sent with added fields
@@ -949,7 +928,6 @@ Deno.test("send should not override existing oauthToken and deviceID", async () 
   // Create test data with existing oauthToken and deviceID
   const customToken = "custom-token";
   const customDeviceId = "custom-device-id";
-  // @ts-ignore - Using simplified test data structure
   const testData = {
     meta: {
       requestID: "test-request-id",
@@ -961,7 +939,7 @@ Deno.test("send should not override existing oauthToken and deviceID", async () 
   };
 
   // Send the data
-  // @ts-ignore - Testing with simplified data structure
+  // @ts-expect-error - Testing with simplified data structure
   connection.send(testData);
 
   // Verify data was sent with original values
@@ -995,7 +973,6 @@ Deno.test("sendAndGetResponse should throw error if socket is not connected", as
   connection.access_token = testToken;
 
   // Create test data
-  // @ts-ignore - Using simplified test data structure
   const testData = {
     meta: {
       requestID: "test-request-id",
@@ -1007,7 +984,7 @@ Deno.test("sendAndGetResponse should throw error if socket is not connected", as
   // This should throw an error
   await assertRejects(
     async () => {
-      // @ts-ignore - Testing with simplified data structure
+      // @ts-expect-error - Testing with simplified data structure
       await connection.sendAndGetResponse(testData);
     },
     Error,
@@ -1034,7 +1011,7 @@ Deno.test("sendAndGetResponse should send data and wait for response", async () 
 
   // Create a mock WebSocket
   const mockWs = mockWebSocket();
-  // @ts-ignore - Accessing private property for testing
+  // @ts-expect-error - Accessing private property for testing
   connection._socket = mockWs;
   // Set the WebSocket to OPEN state
   mockWs.readyState = MockWebSocket.OPEN;
@@ -1061,7 +1038,6 @@ Deno.test("sendAndGetResponse should send data and wait for response", async () 
 
   // Create test data with a request ID
   const requestId = "test-request-id-" + Date.now();
-  // @ts-ignore - Using simplified test data structure
   const testData = {
     meta: {
       requestID: requestId,
@@ -1071,7 +1047,7 @@ Deno.test("sendAndGetResponse should send data and wait for response", async () 
   };
 
   // Call sendAndGetResponse
-  // @ts-ignore - Testing with simplified data structure
+  // @ts-expect-error - Testing with simplified data structure
   const response = await connection.sendAndGetResponse(testData);
 
   // Verify waitFor was called with correct event
@@ -1126,7 +1102,6 @@ Deno.test("sendAndGetResponse should throw PlatformResponseError for critical er
   };
 
   // Create test data
-  // @ts-ignore - Using simplified test data structure
   const testData = {
     meta: {
       requestID: "test-request-id",
@@ -1138,7 +1113,7 @@ Deno.test("sendAndGetResponse should throw PlatformResponseError for critical er
   // Should throw PlatformResponseError
   await assertRejects(
     async () => {
-      // @ts-ignore - Testing with simplified data structure
+      // @ts-expect-error - Testing with simplified data structure
       await connection.sendAndGetResponse(testData);
     },
     PlatformResponseError,
@@ -1203,7 +1178,7 @@ Deno.test("sendAndGetResponse should set deviceID if it's null or default", asyn
 
   // Create a mock WebSocket
   const mockWs = mockWebSocket();
-  // @ts-ignore - Accessing private property for testing
+  // @ts-expect-error - Accessing private property for testing
   connection._socket = mockWs;
   // Set the WebSocket to OPEN state
   mockWs.readyState = MockWebSocket.OPEN;
@@ -1219,7 +1194,6 @@ Deno.test("sendAndGetResponse should set deviceID if it's null or default", asyn
   };
 
   // Test with default UUID
-  // @ts-ignore - Using simplified test data structure
   const testData1 = {
     meta: {
       requestID: "test-request-id",
@@ -1229,7 +1203,7 @@ Deno.test("sendAndGetResponse should set deviceID if it's null or default", asyn
     payload: { test: true },
   };
 
-  // @ts-ignore - Testing with simplified data structure
+  // @ts-expect-error - Testing with simplified data structure
   await connection.sendAndGetResponse(testData1);
 
   // Verify deviceID was set in sent data
@@ -1248,7 +1222,6 @@ Deno.test("sendAndGetResponse should set deviceID if it's null or default", asyn
   mockWs.sentMessages.length = 0;
 
   // Test with null deviceID
-  // @ts-ignore - Using simplified test data structure
   const testData2 = {
     meta: {
       requestID: "test-request-id-2",
@@ -1258,7 +1231,7 @@ Deno.test("sendAndGetResponse should set deviceID if it's null or default", asyn
     payload: { test: true },
   };
 
-  // @ts-ignore - Testing with simplified data structure
+  // @ts-expect-error - Testing with simplified data structure
   await connection.sendAndGetResponse(testData2);
 
   // Verify deviceID was set in sent data
@@ -1305,7 +1278,6 @@ Deno.test(
     await connection.waitFor("open");
 
     // Set a fake refresher
-    // @ts-ignore - Accessing private property for testing
     const mockTimeoutId = connection._refresher;
     // Set up clearTimeout mock
     global.clearTimeout = ((id?: number) => {
@@ -1346,7 +1318,6 @@ Deno.test("close should handle missing socket gracefully", () => {
   );
 
   // Verify no socket exists
-  // @ts-ignore - Accessing private property for testing
   assertEquals(connection._socket, undefined);
 
   // This should not throw an error
@@ -1376,7 +1347,6 @@ Deno.test("Symbol.dispose should clear refresher timeout", () => {
       testTokenUrl,
     );
 
-    // @ts-ignore - Accessing private property for testing
     connection._refresher = mockTimeoutId as unknown as ReturnType<typeof setTimeout>;
 
     // Call Symbol.dispose
@@ -1463,7 +1433,7 @@ Deno.test(
     // Should fail after maxAttempts
     await assertRejects(
       async () => {
-        // @ts-ignore - Accessing private method for testing
+        // @ts-expect-error - Accessing private method for testing
         await connection.authorize();
       },
       Error,
@@ -1736,7 +1706,7 @@ Deno.test(
     const response = await responsePromise;
     assertEquals(response.meta.requestID, responseData.meta.requestID);
     assertEquals(response.meta.messageCode, responseData.meta.messageCode);
-    // @ts-ignore - Testing with simplified data structure
+    // @ts-expect-error - Testing with simplified data structure
     assertEquals(response.payload, responseData.payload);
 
     connection.close();

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -285,7 +285,7 @@ export class Connection extends EventEmitter {
           options = { headers: { Origin: origin } };
         }
 
-        // @ts-ignore - ws library accepts options as third parameter, browser ignores extra params
+        // @ts-expect-error - ws library accepts options as third parameter, browser ignores extra params
         const socket = new global.WebSocket(this._socketURL, undefined, options);
 
         socket.onopen = () => {

--- a/src/cuss2.api-methods.test.ts
+++ b/src/cuss2.api-methods.test.ts
@@ -23,7 +23,7 @@ import { Cuss2 } from "./cuss2.ts";
 
 Deno.test("Section 5.1: getEnvironment - should fetch and store environment data", async () => {
   const mockConnection = new MockConnection();
-  // @ts-ignore - accessing private constructor for testing
+  // @ts-expect-error - accessing private constructor for testing
   const cuss2 = new Cuss2(mockConnection);
 
   // Mock environment response
@@ -51,7 +51,7 @@ Deno.test("Section 5.1: getEnvironment - should fetch and store environment data
 Deno.test("Section 5.1: getEnvironment - should throw when not connected", async () => {
   const mockConnection = new MockConnection();
   mockConnection.isOpen = false;
-  // @ts-ignore - accessing private constructor for testing
+  // @ts-expect-error - accessing private constructor for testing
   const cuss2 = new Cuss2(mockConnection);
 
   await assertRejects(
@@ -63,7 +63,7 @@ Deno.test("Section 5.1: getEnvironment - should throw when not connected", async
 
 Deno.test("Section 5.2: getComponents - should fetch component list and create instances", async () => {
   const mockConnection = new MockConnection();
-  // @ts-ignore - accessing private constructor for testing
+  // @ts-expect-error - accessing private constructor for testing
   const cuss2 = new Cuss2(mockConnection);
 
   // Create mock component list with various types
@@ -118,7 +118,6 @@ Deno.test("Section 5.2: getComponents - should return existing list if component
   const { cuss2, mockConnection } = createMockCuss2();
 
   // Pre-populate components
-  // @ts-ignore - mocking components for testing
   cuss2.components = { "1": {} };
 
   const mockComponentList = createMockComponentList();
@@ -237,7 +236,6 @@ Deno.test("Section 5.5: setup - should validate componentID", async () => {
   const { cuss2 } = createMockCuss2();
 
   await assertRejects(
-    // @ts-ignore - testing invalid input
     () => cuss2.api.setup("invalid", []),
     TypeError,
     "Invalid componentID: invalid",
@@ -271,7 +269,6 @@ Deno.test("Section 5.6: cancel - should validate componentID", async () => {
   const { cuss2 } = createMockCuss2();
 
   await assertRejects(
-    // @ts-ignore - testing invalid input
     () => cuss2.api.cancel(null),
     TypeError,
     "Invalid componentID: null",
@@ -448,28 +445,24 @@ Deno.test("Section 5.8: announcement methods - should validate componentID", asy
   const { cuss2 } = createMockCuss2();
 
   await assertRejects(
-    // @ts-ignore - testing invalid input
     () => cuss2.api.announcement.play(undefined, "data"),
     TypeError,
     "Invalid componentID: undefined",
   );
 
   await assertRejects(
-    // @ts-ignore - testing invalid input
     () => cuss2.api.announcement.pause("123"),
     TypeError,
     "Invalid componentID: 123",
   );
 
   await assertRejects(
-    // @ts-ignore - testing invalid input
     () => cuss2.api.announcement.resume(false),
     TypeError,
     "Invalid componentID: false",
   );
 
   await assertRejects(
-    // @ts-ignore - testing invalid input
     () => cuss2.api.announcement.stop({}),
     TypeError,
     "Invalid componentID: [object Object]",
@@ -507,7 +500,6 @@ Deno.test("Section 5: staterequest - should return undefined if pending state ch
   const { cuss2 } = createMockCuss2();
 
   // Set pending state change
-  // @ts-ignore - accessing private property for testing
   cuss2.pendingStateChange = AppState.AVAILABLE;
 
   const result = await cuss2.api.staterequest(AppState.ACTIVE);

--- a/src/cuss2.component-availability.test.ts
+++ b/src/cuss2.component-availability.test.ts
@@ -17,7 +17,6 @@ Deno.test("Section 7.1: unavailableComponents getter - should return components 
     "4": { id: 4, ready: true, required: false } as unknown as BaseComponent,
   };
 
-  // @ts-ignore - accessing private property for testing
   cuss2.components = mockComponents;
 
   const unavailable = cuss2.unavailableComponents;
@@ -33,7 +32,6 @@ Deno.test("Section 7.1: unavailableComponents getter - should return components 
 Deno.test("Section 7.1: unavailableComponents getter - should return empty array when no components", () => {
   const { cuss2 } = createMockCuss2();
 
-  // @ts-ignore - accessing private property for testing
   cuss2.components = undefined;
 
   const unavailable = cuss2.unavailableComponents;
@@ -54,7 +52,6 @@ Deno.test("Section 7.2: unavailableRequiredComponents getter - should return req
     "5": { id: 5, ready: false, required: true } as unknown as BaseComponent,
   };
 
-  // @ts-ignore - accessing private property for testing
   cuss2.components = mockComponents;
 
   const unavailableRequired = cuss2.unavailableRequiredComponents;
@@ -81,11 +78,9 @@ Deno.test("Section 7.3: checkRequiredComponentsAndSyncState - all required compo
     "3": { id: 3, ready: false, required: false } as unknown as BaseComponent, // Not required, so doesn't matter
   };
 
-  // @ts-ignore - accessing private property for testing
   cuss2.components = mockComponents;
 
   // Set online status directly to avoid triggering checkRequiredComponentsAndSyncState early
-  // @ts-ignore - accessing private property for testing
   cuss2._online = true;
 
   // Spy on requestAvailableState
@@ -106,7 +101,6 @@ Deno.test("Section 7.3: checkRequiredComponentsAndSyncState - some required comp
   setCurrentState(cuss2, AppState.AVAILABLE);
 
   // Set online status directly to avoid triggering checkRequiredComponentsAndSyncState early
-  // @ts-ignore - accessing private property for testing
   cuss2._online = true;
 
   // Create mock components - some required components are not ready
@@ -116,7 +110,6 @@ Deno.test("Section 7.3: checkRequiredComponentsAndSyncState - some required comp
     "3": { id: 3, ready: true, required: false } as unknown as BaseComponent,
   };
 
-  // @ts-ignore - accessing private property for testing
   cuss2.components = mockComponents;
 
   // Spy on requestUnavailableState
@@ -137,7 +130,6 @@ Deno.test("Section 7.3: checkRequiredComponentsAndSyncState - offline → reques
   setCurrentState(cuss2, AppState.AVAILABLE);
 
   // Set offline status directly
-  // @ts-ignore - accessing private property for testing
   cuss2._online = false;
 
   // Create mock components - all ready but we're offline
@@ -146,7 +138,6 @@ Deno.test("Section 7.3: checkRequiredComponentsAndSyncState - offline → reques
     "2": { id: 2, ready: true, required: true } as unknown as BaseComponent,
   };
 
-  // @ts-ignore - accessing private property for testing
   cuss2.components = mockComponents;
 
   // Spy on requestUnavailableState
@@ -164,7 +155,6 @@ Deno.test("Section 7.3: checkRequiredComponentsAndSyncState - should not trigger
   const { cuss2 } = createMockCuss2();
 
   // Set pending state change
-  // @ts-ignore - accessing private property for testing
   cuss2.pendingStateChange = AppState.AVAILABLE;
 
   // Set up conditions that would normally trigger a state change
@@ -176,7 +166,6 @@ Deno.test("Section 7.3: checkRequiredComponentsAndSyncState - should not trigger
     "1": { id: 1, ready: true, required: true } as unknown as BaseComponent,
   };
 
-  // @ts-ignore - accessing private property for testing
   cuss2.components = mockComponents;
 
   // Spy on state request methods
@@ -200,7 +189,6 @@ Deno.test("Section 7.3: checkRequiredComponentsAndSyncState - should not change 
   setCurrentState(cuss2, AppState.AVAILABLE);
 
   // Set online status directly to avoid triggering checkRequiredComponentsAndSyncState early
-  // @ts-ignore - accessing private property for testing
   cuss2._online = true;
 
   // Create mock components - all required components are ready
@@ -208,7 +196,6 @@ Deno.test("Section 7.3: checkRequiredComponentsAndSyncState - should not change 
     "1": { id: 1, ready: true, required: true } as unknown as BaseComponent,
   };
 
-  // @ts-ignore - accessing private property for testing
   cuss2.components = mockComponents;
 
   // Spy on requestAvailableState
@@ -229,11 +216,9 @@ Deno.test("Section 7.3: checkRequiredComponentsAndSyncState - should handle empt
   setCurrentState(cuss2, AppState.UNAVAILABLE);
 
   // Set online status directly to avoid triggering checkRequiredComponentsAndSyncState early
-  // @ts-ignore - accessing private property for testing
   cuss2._online = true;
 
   // Set empty components
-  // @ts-ignore - accessing private property for testing
   cuss2.components = {};
 
   // Spy on requestAvailableState
@@ -254,11 +239,9 @@ Deno.test("Section 7.3: checkRequiredComponentsAndSyncState - offline with no co
   setCurrentState(cuss2, AppState.AVAILABLE);
 
   // Set offline status directly
-  // @ts-ignore - accessing private property for testing
   cuss2._online = false;
 
   // No components set (undefined)
-  // @ts-ignore - accessing private property for testing
   cuss2.components = undefined;
 
   // Spy on requestUnavailableState
@@ -284,7 +267,6 @@ Deno.test("Section 7.1: unavailableComponents getter - should handle mixed compo
     "3": { id: 3 } as unknown as BaseComponent, // ready is undefined, should be treated as not ready
   };
 
-  // @ts-ignore - accessing private property for testing
   cuss2.components = mockComponents;
 
   const unavailable = cuss2.unavailableComponents;
@@ -302,7 +284,6 @@ Deno.test("Section 7.3: checkRequiredComponentsAndSyncState - logs required unav
   setCurrentState(cuss2, AppState.AVAILABLE);
 
   // Set online status directly to avoid triggering checkRequiredComponentsAndSyncState early
-  // @ts-ignore - accessing private property for testing
   cuss2._online = true;
 
   // Mock console log to verify logging
@@ -332,7 +313,6 @@ Deno.test("Section 7.3: checkRequiredComponentsAndSyncState - logs required unav
     "2": mockComponent2,
   };
 
-  // @ts-ignore - accessing private property for testing
   cuss2.components = mockComponents;
 
   // Mock requestUnavailableState to prevent actual state change

--- a/src/cuss2.components.test.ts
+++ b/src/cuss2.components.test.ts
@@ -8,7 +8,7 @@ import { createMockCharacteristics, createMockComponent, MockConnection, mockDev
 
 Deno.test("3.1 - Component discovery should properly create component instances from component list", async () => {
   const mockConnection = new MockConnection();
-  // @ts-ignore - accessing private constructor for testing
+  // @ts-expect-error - accessing private constructor for testing
   const cuss2 = new Cuss2(mockConnection);
 
   // Mock sendAndGetResponse to return component list
@@ -61,7 +61,7 @@ Deno.test("3.1 - Component discovery should properly create component instances 
 
 Deno.test("3.2 - Component type mapping should create correct component class for each type", async () => {
   const mockConnection = new MockConnection();
-  // @ts-ignore - accessing private constructor for testing
+  // @ts-expect-error - accessing private constructor for testing
   const cuss2 = new Cuss2(mockConnection);
 
   // Import component classes for instanceof checks
@@ -157,7 +157,6 @@ Deno.test("3.2 - Component type mapping should create correct component class fo
 
     // Verify property assignment if applicable
     if (ct.property) {
-      // @ts-ignore - accessing dynamic property
       assertEquals(
         cuss2[ct.property] === component,
         true,
@@ -169,7 +168,7 @@ Deno.test("3.2 - Component type mapping should create correct component class fo
 
 Deno.test("3.3 - Feeder/Dispenser linking should create feeders/dispensers before printers for proper linking", async () => {
   const mockConnection = new MockConnection();
-  // @ts-ignore - accessing private constructor for testing
+  // @ts-expect-error - accessing private constructor for testing
   const cuss2 = new Cuss2(mockConnection);
 
   const { Feeder, Dispenser } = await import("./models/index.ts");
@@ -224,7 +223,7 @@ Deno.test("3.3 - Feeder/Dispenser linking should create feeders/dispensers befor
 
 Deno.test("3.4 - Component querying should query all components successfully", async () => {
   const mockConnection = new MockConnection();
-  // @ts-ignore - accessing private constructor for testing
+  // @ts-expect-error - accessing private constructor for testing
   const cuss2 = new Cuss2(mockConnection);
 
   // Import UnknownComponent class
@@ -264,7 +263,7 @@ Deno.test("3.4 - Component querying should query all components successfully", a
 
 Deno.test("3.5 - Component query error handling should handle component query errors gracefully", async () => {
   const mockConnection = new MockConnection();
-  // @ts-ignore - accessing private constructor for testing
+  // @ts-expect-error - accessing private constructor for testing
   const cuss2 = new Cuss2(mockConnection);
 
   // Import UnknownComponent class
@@ -315,7 +314,7 @@ Deno.test("3.5 - Component query error handling should handle component query er
 
 Deno.test("3.1 - Component discovery should handle empty component list", async () => {
   const mockConnection = new MockConnection();
-  // @ts-ignore - accessing private constructor for testing
+  // @ts-expect-error - accessing private constructor for testing
   const cuss2 = new Cuss2(mockConnection);
 
   // Mock empty component list
@@ -337,7 +336,7 @@ Deno.test("3.1 - Component discovery should handle empty component list", async 
 
 Deno.test("3.2 - Component type mapping should create generic UnknownComponent for unknown types", async () => {
   const mockConnection = new MockConnection();
-  // @ts-ignore - accessing private constructor for testing
+  // @ts-expect-error - accessing private constructor for testing
   const cuss2 = new Cuss2(mockConnection);
 
   const { UnknownComponent } = await import("./models/index.ts");

--- a/src/cuss2.connection.test.ts
+++ b/src/cuss2.connection.test.ts
@@ -20,9 +20,9 @@ Deno.test("1.1 - Static connect() method should create a new Cuss2 instance with
   const originalConnect = Connection.connect;
   const mockConnection = new MockConnection();
   // Add Symbol.dispose to mock connection
-  // @ts-ignore - adding dispose for test
+  // @ts-expect-error - adding dispose for test
   mockConnection[Symbol.dispose] = () => {};
-  // @ts-ignore - mocking for test
+  // @ts-expect-error - mocking for test
   Connection.connect = () => mockConnection;
 
   try {
@@ -38,13 +38,11 @@ Deno.test("1.1 - Static connect() method should create a new Cuss2 instance with
     // Verify instance created
     assertEquals(cuss2 instanceof Cuss2, true);
 
-    // @ts-ignore - accessing private property for testing
+    // @ts-expect-error - accessing private property for testing
     assertEquals(cuss2.connection, mockConnection);
 
     // Verify event listeners attached
-    // @ts-ignore - accessing private property for testing
     assertEquals(mockConnection.listenerCount("message"), 1);
-    // @ts-ignore - accessing private property for testing
     assertEquals(mockConnection.listenerCount("open"), 1);
   }
   finally {
@@ -91,7 +89,7 @@ Deno.test("1.3 - Connection not established error should throw when API calls ma
   const mockConnection = new MockConnection();
   mockConnection.isOpen = false;
 
-  // @ts-ignore - accessing private constructor for testing
+  // @ts-expect-error - accessing private constructor for testing
   const cuss2 = new Cuss2(mockConnection);
 
   // Test various API methods
@@ -130,7 +128,6 @@ Deno.test("1.4 - Device ID hydration should update deviceID from environment whe
   cuss2.api.getEnvironment = () => Promise.resolve(createMockEnvironment({ deviceID: testDeviceId }));
 
   // Trigger initialization
-  // @ts-ignore - accessing private method for testing
   await cuss2._initialize();
 
   // Verify device ID was updated
@@ -147,7 +144,6 @@ Deno.test("1.4 - Device ID hydration should not update deviceID when non-default
   cuss2.api.getEnvironment = () => Promise.resolve(createMockEnvironment({ deviceID: "platform-device-id-789" }));
 
   // Trigger initialization
-  // @ts-ignore - accessing private method for testing
   await cuss2._initialize();
 
   // Verify device ID was NOT updated
@@ -156,7 +152,7 @@ Deno.test("1.4 - Device ID hydration should not update deviceID when non-default
 
 Deno.test("1.4 - Device ID hydration should handle null deviceID", async () => {
   const mockConnection = new MockConnection();
-  // @ts-ignore - setting to null for testing
+  // @ts-expect-error - setting to null for testing
   mockConnection.deviceID = null;
   const { cuss2 } = createMockCuss2(mockConnection);
 
@@ -166,7 +162,6 @@ Deno.test("1.4 - Device ID hydration should handle null deviceID", async () => {
   cuss2.api.getEnvironment = () => Promise.resolve(createMockEnvironment({ deviceID: testDeviceId }));
 
   // Trigger initialization
-  // @ts-ignore - accessing private method for testing
   await cuss2._initialize();
 
   // Verify device ID was updated
@@ -177,12 +172,10 @@ Deno.test("1.2 - Initialization should throw error when platform is in abnormal 
   const { cuss2 } = createMockCuss2();
 
   // Set state to undefined to simulate abnormal state
-  // @ts-ignore - accessing private property for testing
   cuss2._currentState = undefined;
 
   // Trigger initialization and expect error
   await assertRejects(
-    // @ts-ignore - accessing private method for testing
     () => cuss2._initialize(),
     Error,
     "Cannot read properties of undefined",
@@ -214,7 +207,6 @@ Deno.test("1.2 - Initialization should emit queryError when component query fail
   cuss2.queryComponents = () => Promise.reject(testError);
 
   // Trigger initialization
-  // @ts-ignore - accessing private method for testing
   await cuss2._initialize();
 
   // Verify queryError was emitted
@@ -235,7 +227,6 @@ Deno.test("1.2 - Initialization should emit connected event after successful ini
   });
 
   // Trigger initialization
-  // @ts-ignore - accessing private method for testing
   await cuss2._initialize();
 
   // Verify connected event was emitted with cuss2 instance
@@ -247,11 +238,10 @@ Deno.test("1.1 - Connected getter should resolve immediately when connection is 
   const mockConnection = new MockConnection();
   mockConnection.isOpen = true;
 
-  // @ts-ignore - accessing private constructor for testing
+  // @ts-expect-error - accessing private constructor for testing
   const cuss2 = new Cuss2(mockConnection);
 
   // Set components to indicate initialization is complete
-  // @ts-ignore - accessing private property for testing
   cuss2.components = { "1": {} };
 
   // Should resolve immediately
@@ -267,7 +257,7 @@ Deno.test("1.1 - Connected getter should wait for connected event when connectio
   const mockConnection = new MockConnection();
   mockConnection.isOpen = false;
 
-  // @ts-ignore - accessing private constructor for testing
+  // @ts-expect-error - accessing private constructor for testing
   const cuss2 = new Cuss2(mockConnection);
 
   let resolved = false;
@@ -293,7 +283,7 @@ Deno.test("1.1 - Connected getter should reject on authentication error", async 
   const mockConnection = new MockConnection();
   mockConnection.isOpen = false;
 
-  // @ts-ignore - accessing private constructor for testing
+  // @ts-expect-error - accessing private constructor for testing
   const cuss2 = new Cuss2(mockConnection);
 
   // Start waiting for connected

--- a/src/cuss2.data-communication.test.ts
+++ b/src/cuss2.data-communication.test.ts
@@ -28,7 +28,6 @@ Deno.test("Section 4.1: Platform data message processing - should process platfo
     payload: {},
   } as unknown as PlatformData;
 
-  // @ts-ignore - accessing private method for testing
   await cuss2._handleWebSocketMessage(platformData);
 
   // Verify state was updated
@@ -59,7 +58,6 @@ Deno.test("Section 4.2: Session timeout handling - should emit sessionTimeout ev
     payload: {},
   } as unknown as PlatformData;
 
-  // @ts-ignore - accessing private method for testing
   await cuss2._handleWebSocketMessage(platformData);
 
   // Verify sessionTimeout event was emitted
@@ -84,7 +82,6 @@ Deno.test("Section 4.3: Invalid state handling - should close connection on inva
 
   // Should throw error synchronously
   assertThrows(
-    // @ts-ignore - accessing private method for testing
     () => cuss2._handleWebSocketMessage(platformData),
     Error,
     "Platform in invalid state. Cannot continue.",
@@ -105,7 +102,6 @@ Deno.test("Section 4.4: Component state updates - should update component states
     updateState: () => {},
   };
 
-  // @ts-ignore - accessing private property for testing
   cuss2.components = { "1": mockComponent };
 
   // Create spy for component state change event
@@ -132,13 +128,12 @@ Deno.test("Section 4.4: Component state updates - should update component states
     },
   } as unknown as PlatformData;
 
-  // @ts-ignore - accessing private method for testing
   await cuss2._handleWebSocketMessage(platformData);
 
   // Verify component methods were called
   assertEquals(stateIsDifferentStub.calls.length, 1);
   assertEquals(updateStateSpy.calls.length, 1);
-  // @ts-ignore - spy type issue
+  // @ts-expect-error - spy type issue
   assertEquals(updateStateSpy.calls[0]?.args?.[0], platformData);
 
   // Verify componentStateChange event was emitted
@@ -164,7 +159,6 @@ Deno.test("Section 4.5: Unsolicited messages - should handle unsolicited compone
     updateState: () => {},
   };
 
-  // @ts-ignore - accessing private property for testing
   cuss2.components = { "1": mockComponent };
 
   // Mock component stateIsDifferent to return true
@@ -188,7 +182,6 @@ Deno.test("Section 4.5: Unsolicited messages - should handle unsolicited compone
     },
   } as unknown as PlatformData;
 
-  // @ts-ignore - accessing private method for testing
   await cuss2._handleWebSocketMessage(platformData);
 
   // Verify checkRequiredComponentsAndSyncState was called for unsolicited message
@@ -223,7 +216,6 @@ Deno.test("Section 4.1: Platform data message - activated event on ACTIVE state"
     },
   } as unknown as PlatformData;
 
-  // @ts-ignore - accessing private method for testing
   await cuss2._handleWebSocketMessage(platformData);
 
   // Verify state and activation properties
@@ -306,7 +298,6 @@ Deno.test("Section 4.4: Component state updates - should check sync state for QU
     updateState: () => {},
   };
 
-  // @ts-ignore - accessing private property for testing
   cuss2.components = { "1": mockComponent };
 
   // Mock component stateIsDifferent to return true
@@ -333,7 +324,6 @@ Deno.test("Section 4.4: Component state updates - should check sync state for QU
     },
   } as unknown as PlatformData;
 
-  // @ts-ignore - accessing private method for testing
   await cuss2._handleWebSocketMessage(platformData);
 
   // Verify checkRequiredComponentsAndSyncState was called
@@ -350,7 +340,6 @@ Deno.test("Section 4: Edge case - handle null platform data gracefully", async (
   cuss2.on("message", messageSpy);
 
   // Send null platform data
-  // @ts-ignore - testing null input
   await cuss2._handleWebSocketMessage(null);
 
   // Should return early without emitting any events
@@ -360,7 +349,6 @@ Deno.test("Section 4: Edge case - handle null platform data gracefully", async (
 Deno.test("Section 4: Edge case - handle missing component gracefully", async () => {
   const { cuss2 } = createMockCuss2();
 
-  // @ts-ignore - accessing private property for testing
   cuss2.components = {};
 
   const componentStateChangeSpy = spy();
@@ -376,7 +364,6 @@ Deno.test("Section 4: Edge case - handle missing component gracefully", async ()
     payload: {},
   } as unknown as PlatformData;
 
-  // @ts-ignore - accessing private method for testing
   await cuss2._handleWebSocketMessage(platformData);
 
   // Should not emit componentStateChange for missing component

--- a/src/cuss2.state-requests.test.ts
+++ b/src/cuss2.state-requests.test.ts
@@ -9,7 +9,7 @@ import type { InteractiveComponent } from "./models/index.ts";
 
 Deno.test("Section 6.1: requestInitializeState - should transition from STOPPED to INITIALIZE", async () => {
   const mockConnection = new MockConnection();
-  // @ts-ignore - accessing private constructor for testing
+  // @ts-expect-error - accessing private constructor for testing
   const cuss2 = new Cuss2(mockConnection);
 
   // Set initial state to STOPPED
@@ -116,7 +116,6 @@ Deno.test("Section 6.2: requestUnavailableState - should disable components when
     disable: () => Promise.resolve(),
   } as unknown as InteractiveComponent;
 
-  // @ts-ignore - accessing private property for testing
   cuss2.components = {
     "1": mockComponent1,
     "2": mockComponent2,
@@ -197,7 +196,6 @@ Deno.test("Section 6.3: requestAvailableState - should disable components when t
     disable: () => Promise.resolve(),
   } as unknown as InteractiveComponent;
 
-  // @ts-ignore - accessing private property for testing
   cuss2.components = { "1": mockComponent };
 
   const disableSpy = spy(mockComponent, "disable");
@@ -436,7 +434,6 @@ Deno.test("Section 6: _disableAllComponents - should disable all enabled compone
     { enabled: true, disable: () => Promise.resolve() },
   ];
 
-  // @ts-ignore - accessing private property for testing
   cuss2.components = {
     "1": components[0],
     "2": components[1],
@@ -445,7 +442,6 @@ Deno.test("Section 6: _disableAllComponents - should disable all enabled compone
 
   const disableSpies = components.map((c) => spy(c, "disable"));
 
-  // @ts-ignore - accessing private method for testing
   await cuss2._disableAllComponents();
 
   // Verify only enabled components were disabled

--- a/src/cuss2.state.test.ts
+++ b/src/cuss2.state.test.ts
@@ -15,7 +15,7 @@ import {
 
 Deno.test("2.1 - Initial state should be STOPPED", () => {
   const mockConnection = new MockConnection();
-  // @ts-ignore - accessing private constructor for testing
+  // @ts-expect-error - accessing private constructor for testing
   const cuss2 = new Cuss2(mockConnection);
 
   // Verify initial state
@@ -48,7 +48,6 @@ Deno.test("2.2 - State transitions should handle valid state transitions correct
   }
 
   // Mock disable for components
-  // @ts-ignore - accessing private method for testing
   cuss2._disableAllComponents = () => Promise.resolve();
 
   // Test STOPPED → INITIALIZE
@@ -117,7 +116,6 @@ Deno.test("2.5 - Pending state changes should prevent concurrent state change re
   };
 
   // Set state to allow transition
-  // @ts-ignore - accessing private property for testing
   cuss2._currentState = new StateChange(AppState.UNAVAILABLE, AppState.UNAVAILABLE);
 
   // Make two concurrent requests
@@ -198,7 +196,6 @@ Deno.test("2.2 - State transitions should disable all components when transition
 
   // Track if _disableAllComponents was called
   let disableAllCalled = false;
-  // @ts-ignore - accessing private method for testing
   cuss2._disableAllComponents = () => {
     disableAllCalled = true;
     return Promise.resolve();
@@ -232,7 +229,6 @@ Deno.test("2.6 - State transitions should proceed even when individual component
   };
 
   // Add the mock component to the components list
-  // @ts-ignore - accessing private property for testing
   cuss2.components = { "123": mockComponent };
 
   // Test ACTIVE → AVAILABLE with component disable failure

--- a/src/data-present.test.ts
+++ b/src/data-present.test.ts
@@ -39,11 +39,8 @@ function buildDataPresentMessage(
 
 // Helper: set up a component in a mock cuss2 for end-to-end testing
 function setupComponent(cuss2: ReturnType<typeof createMockCuss2>["cuss2"], component: { id: number }) {
-  // @ts-ignore: accessing private for testing
   if (!cuss2.components) cuss2.components = {};
-  // @ts-ignore: accessing private for testing
   cuss2.components[String(component.id)] = component;
-  // @ts-ignore: accessing private for testing
   cuss2._currentState = new StateChange(AppState.ACTIVE, AppState.ACTIVE);
 }
 
@@ -99,7 +96,6 @@ Deno.test("DATA_PRESENT - full pipeline via _handleWebSocketMessage", () => {
 
   const msg = buildDataPresentMessage(5, records, AppState.ACTIVE);
 
-  // @ts-ignore: accessing private method for testing
   cuss2._handleWebSocketMessage(msg);
 
   assertEquals(messageSpy.calls.length >= 1, true, "cuss2 'message' event should have fired");
@@ -126,9 +122,7 @@ Deno.test("DATA_PRESENT - second scan also triggers data event", () => {
     { data: "SCAN_2", dsTypes: ["DS_TYPES_BARCODE"] },
   ] as unknown as DataRecord[];
 
-  // @ts-ignore: accessing private method for testing
   cuss2._handleWebSocketMessage(buildDataPresentMessage(5, records1, AppState.ACTIVE));
-  // @ts-ignore: accessing private method for testing
   cuss2._handleWebSocketMessage(buildDataPresentMessage(5, records2, AppState.ACTIVE));
 
   assertEquals(dataSpy.calls.length, 2, "data event should have fired twice (once per scan)");
@@ -157,7 +151,6 @@ Deno.test("DATA_PRESENT - does NOT emit data event without dataRecords", () => {
     payload: {},
   } as unknown as PlatformData;
 
-  // @ts-ignore: accessing private method for testing
   cuss2._handleWebSocketMessage(msg);
 
   assertEquals(dataSpy.calls.length, 0, "data event should NOT fire without dataRecords");
@@ -178,7 +171,6 @@ Deno.test("DATA_PRESENT - Keypad emits 'data' event with parsed key data", () =>
     { data: "NAVNEXT", dsTypes: ["DS_TYPES_KEY"], dataStatus: "DS_OK" },
   ] as unknown as DataRecord[];
 
-  // @ts-ignore: accessing private method for testing
   cuss2._handleWebSocketMessage(buildDataPresentMessage(0, records, AppState.ACTIVE));
 
   assertEquals(dataSpy.calls.length, 1, "Keypad 'data' event should have fired");

--- a/src/models/Printer.test.ts
+++ b/src/models/Printer.test.ts
@@ -307,7 +307,7 @@ Deno.test("Printer updateState should handle CUT n HOLD timeout correctly", () =
   printer.updateState(timeoutMessage);
 
   // Component state should be READY, not UNAVAILABLE
-  // @ts-ignore - accessing private property for testing
+  // @ts-expect-error - accessing private property for testing
   assertEquals(printer._componentState, ComponentState.READY);
   assert(readyStateChangeEmitted);
 });
@@ -330,7 +330,7 @@ Deno.test("Printer updateState should query linked components when becoming read
   };
 
   // Start with printer not ready
-  // @ts-ignore - accessing private property for testing
+  // @ts-expect-error - accessing private property for testing
   printer._componentState = ComponentState.UNAVAILABLE;
 
   // Update to ready state
@@ -471,7 +471,7 @@ Deno.test("Printer getPairedResponse should split response correctly", async () 
     payload: [{ data: "LSOK123456789ABC" }] as DataRecordList,
   } as PlatformData;
 
-  // @ts-ignore - accessing protected method for testing
+  // @ts-expect-error - accessing protected method for testing
   const pairs = await printer.getPairedResponse("LS", 2);
 
   // Should split after "OK" into pairs of 2

--- a/src/test-helpers.ts
+++ b/src/test-helpers.ts
@@ -105,7 +105,7 @@ export function createMockComponentList(): ComponentList {
 // Helper to create a Cuss2 instance with mocked dependencies
 export function createMockCuss2(connection?: MockConnection) {
   const mockConnection = connection || new MockConnection();
-  // @ts-ignore - accessing private constructor for testing
+  // @ts-expect-error - accessing private constructor for testing
   const cuss2 = new Cuss2(mockConnection);
 
   // Mock the api methods
@@ -114,7 +114,6 @@ export function createMockCuss2(connection?: MockConnection) {
   cuss2.queryComponents = () => Promise.resolve(true);
 
   // Set initial state
-  // @ts-ignore - accessing private property for testing
   cuss2._currentState = new StateChange(AppState.UNAVAILABLE, AppState.UNAVAILABLE);
 
   return { cuss2, mockConnection };
@@ -126,7 +125,7 @@ export async function simulateStateChange(
   newState: AppState,
   payload?: unknown,
 ): Promise<void> {
-  // @ts-ignore - accessing private method for testing
+  // @ts-expect-error - accessing private method for testing
   await cuss2._handleWebSocketMessage({
     meta: {
       currentApplicationState: { applicationStateCode: newState },
@@ -138,7 +137,7 @@ export async function simulateStateChange(
 
 // Helper to set current state
 export function setCurrentState(cuss2: Cuss2, state: AppState): void {
-  // @ts-ignore - accessing private property for testing
+  // @ts-expect-error - accessing private property for testing
   cuss2._currentState = new StateChange(state, state);
 }
 
@@ -183,12 +182,10 @@ export async function testInitializationThrowsForState(state: AppState) {
   const { cuss2 } = createMockCuss2();
 
   // Set state
-  // @ts-ignore - accessing private property for testing
   cuss2._currentState = new StateChange(state, state);
 
   // Trigger initialization and expect error
   await assertRejects(
-    // @ts-ignore - accessing private method for testing
     () => cuss2._initialize(),
     Error,
     `Platform has ${state} the application`,


### PR DESCRIPTION
### What

Converts all **165** `@ts-ignore` directives in cuss2-ts to `@ts-expect-error`, then removes the ones that turn out to be dead.

`@ts-expect-error` is strictly better than `@ts-ignore`: it is **self-cleaning** — TypeScript raises `TS2578 "Unused '@ts-expect-error' directive"` if the guarded line stops having an error. `@ts-ignore` silently lingers forever (and neither `deno lint` nor `deno check` flags it), which is how 200+ of them accumulated.

### What it surfaced

**106 of the 165 suppressed nothing** — dead directives, mostly `// @ts-ignore - accessing private property/method for testing` sitting above accesses to members that aren't actually TS-`private` (underscore is just a naming convention). Those 106 are removed. The **59** genuinely-needed ones remain as `@ts-expect-error`.

Scope: only directive **comment lines** were touched — verified no code line was altered. The 1 vendored `@ts-nocheck` (`vendor/node-events-fixed.ts`) is left as-is.

### Verification

- `deno lint` → clean (78 files).
- `deno check --no-lock` on all changed files → **0** `TS2578`, and the only remaining errors are the **8 pre-existing** `setTimeout`/`Timeout` mock-typing errors (unchanged from master — 0 new). No genuinely-needed suppression was removed (would have appeared as a new non-TS2578 error).
- `deno test` → **256 passed | 0 failed**.

Note: overlaps files with the two open cuss2-ts PRs (#52 deno-lint cleanup, #53 authenticated-event type) but on different lines — merges cleanly.
