### PR TITLE
ci: run on pull requests to any base, not only the default branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,10 @@ name: CI
 on:
   push:
     branches: [main, master]
+  # No `branches:` filter. That filter matches the pull request's BASE, so a PR
+  # targeting anything else — every layer of a stack above the bottom one — ran no
+  # workflow at all and reported "no checks", while still showing mergeable.
   pull_request:
-    branches: [main, master]
 
 permissions:
   contents: read


### PR DESCRIPTION
The `branches:` filter under `pull_request` matches the pull request's **base** branch. A PR targeting anything not in that list matches nothing, so **no workflow runs at all**.

GitHub does not surface that as a failure. It reports `no checks reported` and the PR still shows as mergeable — so a PR can sit there looking ready with nothing having run against it. Every PR based on another PR's branch hits this.

The `push` trigger keeps its filter: that one matches the pushed branch, which is what it was always for.