### PR TITLE
ci: run on pull requests to any base, not only the default branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,10 @@ name: CI
 on:
   push:
     branches: [main, master]
+  # No `branches:` filter. That filter matches the pull request's BASE, so a PR
+  # targeting anything else — every layer of a stack above the bottom one — ran no
+  # workflow at all and reported "no checks", while still showing mergeable.
   pull_request:
-    branches: [main, master]
 
 permissions:
   contents: read


### PR DESCRIPTION
**Part of a 59-PR sequenced release across 15 repositories — do not merge in isolation.** Merge order, the package publishes that sit between repositories, and which failing checks are expected and what clears them are all in the [merge runbook](https://claude.ai/code/artifact/51daa277-8558-499d-ba17-3645101ca052). Find this PR's phase there before merging it.

---

**Targets `master` directly.** Merge position **3 of 7** in this repository's queue — the order matters, the base does not.

---

The `branches:` filter under `pull_request` matches the pull request's base branch. A PR targeting anything not in that list matches nothing, so no workflow runs at all.

GitHub does not surface that as a failure. It reports `no checks reported` and the PR still shows as mergeable — so a PR can sit there looking ready with nothing having run against it. Every PR based on another PR's branch hits this.

The `push` trigger keeps its filter: that one matches the pushed branch, which is what it was always for.