### PR TITLE
Fix authenticated event payload type

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -16,7 +16,7 @@ interface ConnectionEvents {
   open: [];
   authenticating: [number];
   connecting: [number];
-  authenticated: [typeof Connection.prototype._auth];
+  authenticated: [AuthResponse];
   messageError: [unknown];
   socketError: [unknown];
   authenticationError: [AuthenticationError];


### PR DESCRIPTION
**Part of a 59-PR sequenced release across 15 repositories — do not merge in isolation.** Merge order, the package publishes that sit between repositories, and which failing checks are expected and what clears them are all in the [merge runbook](https://claude.ai/code/artifact/51daa277-8558-499d-ba17-3645101ca052). Find this PR's phase there before merging it.

---

**Targets `master` directly.** Merge position **4 of 7** in this repository's queue — the order matters, the base does not.