### PR TITLE
feat(tester): ADA headset + keypad help UI with device-help tooltip

### DIFF
--- a/docs/examples/css/tester.css
+++ b/docs/examples/css/tester.css
@@ -898,6 +898,112 @@ input.field-problem {
   letter-spacing: 0.5px;
 }
 
+/* ─── HelpTooltip component ──────────────────────────────────────────────
+   Hover-triggered popover showing a component's deviceHelpInstruction SSML
+   as descriptive ADA text. Mirrors the char-popover hover pattern used by
+   the device-name tooltip (tester.js:startCharHover) — 500ms open delay,
+   200ms close-delay grace so the cursor can travel into the popover. */
+
+.help-tooltip-container {
+  position: relative;
+  display: inline-block;
+  vertical-align: middle;
+  margin-left: 6px;
+}
+
+/* Round "?" badge inline with the label. */
+.device-help-tip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1;
+  color: #0b0d17;
+  background: rgba(100, 255, 218, 0.75);
+  border-radius: 50%;
+  cursor: help;
+  text-transform: none;
+  letter-spacing: 0;
+  user-select: none;
+  transition: background 0.15s ease, transform 0.1s ease;
+}
+
+.device-help-tip:hover,
+.device-help-tip.active {
+  background: #64ffda;
+  transform: scale(1.08);
+}
+
+/* Popover anchored beneath the ? badge. Matches .char-popover aesthetic. */
+.help-tooltip-popover {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 100;
+  width: 380px;
+  max-width: calc(100vw - 32px);
+  max-height: 420px;
+  overflow-y: auto;
+  background: #1a1a2e;
+  border: 1px solid rgba(100, 255, 218, 0.3);
+  border-radius: 6px;
+  padding: 12px 14px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
+  /* Reset inherited label styling so popover contents read naturally. */
+  text-transform: none;
+  letter-spacing: normal;
+  font-weight: 400;
+  color: #e0e0e0;
+  text-align: left;
+}
+
+.help-tooltip-title {
+  font-size: 11px;
+  font-weight: 600;
+  color: #64ffda;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding-bottom: 8px;
+  margin-bottom: 10px;
+  border-bottom: 1px solid rgba(100, 255, 218, 0.2);
+}
+
+.help-tooltip-body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.help-tooltip-entry {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.help-tooltip-label {
+  font-size: 10px;
+  font-weight: 600;
+  color: rgba(100, 255, 218, 0.7);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.help-tooltip-text {
+  font-size: 13px;
+  color: #e0e0e0;
+  line-height: 1.5;
+}
+
+.help-tooltip-empty {
+  font-size: 12px;
+  color: rgba(224, 224, 224, 0.6);
+  font-style: italic;
+  line-height: 1.5;
+}
+
 .component-action-controls {
   display: flex;
   gap: 8px;
@@ -1877,4 +1983,83 @@ input.field-problem {
   background: rgba(211, 47, 47, 0.9);
   border-color: rgba(211, 47, 47, 0.6);
   color: #fff;
+}
+
+/* ===== HEADSET ===== */
+.headset-jack-indicator {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.03);
+  transition: background 0.25s ease, border-color 0.25s ease, color 0.25s ease;
+}
+
+.headset-jack-indicator.headset-jack-present {
+  background: rgba(100, 255, 218, 0.12);
+  border-color: rgba(100, 255, 218, 0.5);
+  color: #64ffda;
+}
+
+.headset-jack-indicator.headset-jack-absent {
+  background: rgba(160, 160, 160, 0.08);
+  border-color: rgba(160, 160, 160, 0.3);
+  color: #a0a0a0;
+}
+
+.headset-jack-indicator.headset-jack-unknown {
+  background: rgba(255, 193, 7, 0.1);
+  border-color: rgba(255, 193, 7, 0.4);
+  color: #ffc107;
+}
+
+.headset-jack-icon {
+  font-size: 24px;
+  line-height: 1;
+}
+
+.headset-jack-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.headset-jack-label {
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+}
+
+.headset-jack-time {
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.4);
+}
+
+.headset-help-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.headset-help-entry {
+  padding: 6px 10px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 4px;
+}
+
+.headset-help-label {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  color: rgba(100, 255, 218, 0.7);
+  margin-bottom: 2px;
+}
+
+.headset-help-text {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.75);
+  line-height: 1.4;
 }

--- a/docs/examples/js/tester/components/Headset.js
+++ b/docs/examples/js/tester/components/Headset.js
@@ -4,5 +4,70 @@ export default {
     component: { type: Object, required: true },
     componentId: { type: String, required: true },
   },
-  template: `<div></div>`,
+  emits: ['log'],
+  data() {
+    return {
+      speakPending: false,
+    };
+  },
+  computed: {
+    /**
+     * Extract deviceHelpInstruction SSML sections into plain-text lines.
+     * The c2p-headset plugin publishes componentCharacteristics[].deviceHelpInstruction
+     * describing the physical jack/volume per CUSS2 spec §2.5.
+     */
+    helpLines() {
+      const lines = [];
+      const chars = this.component?._component?.componentCharacteristics || [];
+      const order = [
+        ['deviceDescription', 'Description'],
+        ['deviceLocation', 'Location'],
+        ['deviceProfile', 'Profile'],
+        ['deviceUsage', 'Usage'],
+      ];
+      for (const ch of chars) {
+        const instruction = ch?.deviceHelpInstruction?.instruction;
+        if (!instruction) continue;
+        for (const [key, label] of order) {
+          const elements = instruction[key];
+          const first = Array.isArray(elements) ? elements[0] : null;
+          const ssml = first?.ssmlElement;
+          if (!ssml) continue;
+          const text = ssml.replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim();
+          if (text) lines.push({ label, text });
+        }
+      }
+      return lines;
+    },
+  },
+  methods: {
+    async speakHelp() {
+      if (this.speakPending) return;
+      this.speakPending = true;
+      try {
+        await this.$root.playHeadsetHelp(this.component);
+      } finally {
+        this.speakPending = false;
+      }
+    },
+  },
+  template: `
+    <div class="component-actions-row">
+      <div class="component-action-column left-column">
+        <label class="component-action-label">
+          Device Help
+          <help-tooltip :lines="helpLines" title="Headset Help Instruction" />
+        </label>
+        <div class="component-action-buttons">
+          <button class="component-action-btn"
+                  :class="{ loading: speakPending }"
+                  :disabled="speakPending || !helpLines.length"
+                  @click="speakHelp">
+            <span class="btn-label">Speak Device Help</span>
+            <span class="btn-spinner"></span>
+          </button>
+        </div>
+      </div>
+    </div>
+  `,
 };

--- a/docs/examples/js/tester/components/HelpTooltip.js
+++ b/docs/examples/js/tester/components/HelpTooltip.js
@@ -1,0 +1,93 @@
+/**
+ * Hover-triggered help tooltip. Renders a "?" badge next to a label;
+ * hovering opens a styled popover containing the component's
+ * deviceHelpInstruction SSML sections as descriptive ADA text.
+ *
+ * Matches the existing char-popover pattern used for the device-name
+ * hover (tester.js:startCharHover): 500ms open delay, 200ms close-delay
+ * grace so the cursor can travel into the popover without it closing.
+ *
+ * Usage:
+ *   <help-tooltip :lines="helpLines" title="Keypad Help Instruction" />
+ *
+ * Each entry in `lines` is { label: string, text: string }.
+ */
+export default {
+  name: 'HelpTooltip',
+  props: {
+    lines: { type: Array, default: () => [] },
+    title: { type: String, default: 'Device Help Instruction' },
+  },
+  data() {
+    return {
+      visible: false,
+    };
+  },
+  beforeUnmount() {
+    this._clearOpenTimer();
+    this._clearCloseTimer();
+  },
+  methods: {
+    _clearOpenTimer() {
+      if (this._openTimer) {
+        clearTimeout(this._openTimer);
+        this._openTimer = null;
+      }
+    },
+    _clearCloseTimer() {
+      if (this._closeTimer) {
+        clearTimeout(this._closeTimer);
+        this._closeTimer = null;
+      }
+    },
+    onBadgeEnter() {
+      this._clearCloseTimer();
+      if (this.visible) return;
+      this._clearOpenTimer();
+      this._openTimer = setTimeout(() => {
+        this.visible = true;
+      }, 500);
+    },
+    onBadgeLeave() {
+      this._clearOpenTimer();
+      this._scheduleClose();
+    },
+    onPopoverEnter() {
+      this._clearCloseTimer();
+    },
+    onPopoverLeave() {
+      this._scheduleClose();
+    },
+    _scheduleClose() {
+      this._clearCloseTimer();
+      this._closeTimer = setTimeout(() => {
+        this.visible = false;
+      }, 200);
+    },
+  },
+  template: `
+    <span class="help-tooltip-container">
+      <span class="device-help-tip"
+            :class="{ active: visible }"
+            role="img"
+            :aria-label="title"
+            @mouseenter="onBadgeEnter"
+            @mouseleave="onBadgeLeave">?</span>
+      <div v-if="visible"
+           class="help-tooltip-popover"
+           @mouseenter="onPopoverEnter"
+           @mouseleave="onPopoverLeave">
+        <div class="help-tooltip-title">{{ title }}</div>
+        <div v-if="lines.length" class="help-tooltip-body">
+          <div v-for="(line, i) in lines" :key="i" class="help-tooltip-entry">
+            <div class="help-tooltip-label">{{ line.label }}</div>
+            <div class="help-tooltip-text">{{ line.text }}</div>
+          </div>
+        </div>
+        <div v-else class="help-tooltip-empty">
+          No deviceHelpInstruction published by the platform for this component.
+        </div>
+      </div>
+    </span>
+  `,
+};

--- a/docs/examples/js/tester/components/Keypad.js
+++ b/docs/examples/js/tester/components/Keypad.js
@@ -27,6 +27,37 @@ export default {
       buttonStates: {},
     };
   },
+  computed: {
+    /**
+     * Extract deviceHelpInstruction SSML sections into plain-text lines.
+     * The uNav keypad plugin (and NavPad/AudioNav variants) publishes
+     * componentCharacteristics[].deviceHelpInstruction describing the
+     * physical keypad — layout, location, usage — per CUSS2 spec §2.5.
+     */
+    helpLines() {
+      const lines = [];
+      const chars = this.component?._component?.componentCharacteristics || [];
+      const order = [
+        ['deviceDescription', 'Description'],
+        ['deviceLocation', 'Location'],
+        ['deviceProfile', 'Profile'],
+        ['deviceUsage', 'Usage'],
+      ];
+      for (const ch of chars) {
+        const instruction = ch?.deviceHelpInstruction?.instruction;
+        if (!instruction) continue;
+        for (const [key, label] of order) {
+          const elements = instruction[key];
+          const first = Array.isArray(elements) ? elements[0] : null;
+          const ssml = first?.ssmlElement;
+          if (!ssml) continue;
+          const text = ssml.replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim();
+          if (text) lines.push({ label, text });
+        }
+      }
+      return lines;
+    },
+  },
   methods: {
     async handleSetup(mode, buttonKey) {
       this.buttonStates[buttonKey] = 'loading';
@@ -86,7 +117,10 @@ export default {
   template: `
     <div class="component-actions-row">
       <div class="component-action-column left-column">
-        <label class="component-action-label">Setup Mode</label>
+        <label class="component-action-label">
+          Setup Mode
+          <help-tooltip :lines="helpLines" title="Keypad Help Instruction" />
+        </label>
         <div class="component-action-buttons">
           <button class="component-action-btn"
                   :class="btnClasses('kp-key')"

--- a/docs/examples/js/tester/tester.js
+++ b/docs/examples/js/tester/tester.js
@@ -2,6 +2,7 @@ import { Cuss2, Models, criticalErrors } from '../../../dist/cuss2.esm.js';
 import { aeaCommandsData, loadCompanyLogo, NO_RECONNECT_CODES } from './data.js';
 import { extractStatusCodeFromError, validateURL, generateOAuthUrl } from './utils.js';
 import ToggleSwitch from './components/ToggleSwitch.js';
+import HelpTooltip from './components/HelpTooltip.js';
 import Keypad from './components/Keypad.js';
 import Headset from './components/Headset.js';
 import GenericComponent from './components/GenericComponent.js';
@@ -127,8 +128,7 @@ const app = createApp({
     },
 
     allCollapsed() {
-      const collapsible = this.componentList.filter(([, c]) => !this.isHeaderOnly(c));
-      return collapsible.length > 0 && collapsible.every(([id]) => this.collapsedComponents[id]);
+      return this.componentList.length > 0 && this.componentList.every(([id]) => this.collapsedComponents[id]);
     },
 
     allowedTransitions() {
@@ -586,7 +586,16 @@ const app = createApp({
 
       cuss2.on('componentStateChange', (component) => {
         this.logEvent(`Component ${component.deviceType} state changed`);
+        const prev = this.componentStatuses[component.id]?.status;
         this.refreshComponent(component.id);
+        // Per CUSS2 spec §2.5 / §3.8, apps should react to headset insertion
+        // by speaking device help via the linked AAO. Trigger on the
+        // MEDIA_ABSENT → MEDIA_PRESENT transition (not repeated emissions).
+        if (component.deviceType === 'HEADSET'
+            && component.status === 'MEDIA_PRESENT'
+            && prev !== 'MEDIA_PRESENT') {
+          this.playHeadsetHelp(component);
+        }
       });
 
       cuss2.on('sessionTimeout', () => {
@@ -755,11 +764,6 @@ const app = createApp({
       }
     },
 
-    isHeaderOnly(component) {
-      const headerOnlyTypes = ['HEADSET'];
-      return headerOnlyTypes.includes(component.deviceType);
-    },
-
     initComponents() {
       if (!cuss2?.components) return;
       const comps = {};
@@ -768,6 +772,7 @@ const app = createApp({
         comps[id] = component;
         const displayStatus = component.status || 'OK';
         statuses[id] = {
+          status: displayStatus,
           statusBadge: displayStatus.replace(/_/g, ' '),
           statusClass: this.statusClass(displayStatus),
         };
@@ -804,8 +809,70 @@ const app = createApp({
     updateComponentStatus(id, status) {
       if (!this.componentStatuses[id]) return;
       const displayStatus = status || 'OK';
+      this.componentStatuses[id].status = displayStatus;
       this.componentStatuses[id].statusBadge = displayStatus.replace(/_/g, ' ');
       this.componentStatuses[id].statusClass = this.statusClass(displayStatus);
+    },
+
+    /**
+     * Find the Announcement (AAO) component linked to this headset.
+     * Per CUSS2 §3.5.2.1 the AAO is a MediaInput linked to an Announcement
+     * via linkedComponentIDs. Fall back to any Announcement if linking is
+     * absent (dev/mock setups).
+     */
+    findLinkedAnnouncement(headset) {
+      const linkedIds = headset?._component?.linkedComponentIDs || [];
+      for (const lid of linkedIds) {
+        const linked = cuss2?.components?.[lid];
+        if (linked?.deviceType === 'ANNOUNCEMENT') return linked;
+      }
+      if (!cuss2?.components) return null;
+      for (const comp of Object.values(cuss2.components)) {
+        if (comp.deviceType === 'ANNOUNCEMENT') return comp;
+      }
+      return null;
+    },
+
+    /** Collect the Headset's deviceHelpInstruction SSML elements in spec order. */
+    collectHeadsetHelpSsml(headset) {
+      const chars = headset?._component?.componentCharacteristics || [];
+      const order = ['deviceDescription', 'deviceLocation', 'deviceProfile', 'deviceUsage'];
+      const out = [];
+      for (const ch of chars) {
+        const instruction = ch?.deviceHelpInstruction?.instruction;
+        if (!instruction) continue;
+        for (const key of order) {
+          const elements = instruction[key];
+          const first = Array.isArray(elements) ? elements[0] : null;
+          if (first?.ssmlElement) out.push(first.ssmlElement);
+        }
+      }
+      return out;
+    },
+
+    async playHeadsetHelp(headset) {
+      const announcement = this.findLinkedAnnouncement(headset);
+      if (!announcement) {
+        this.logError('Headset inserted but no ANNOUNCEMENT component available to speak device help');
+        return;
+      }
+      const ssmlElements = this.collectHeadsetHelpSsml(headset);
+      if (!ssmlElements.length) {
+        this.logInfo('Headset has no deviceHelpInstruction SSML to speak');
+        return;
+      }
+      try {
+        if (typeof announcement.enable === 'function' && !announcement.enabled) {
+          await announcement.enable();
+        }
+        this.logInfo(`Speaking headset device help (${ssmlElements.length} section(s))`);
+        for (const ssml of ssmlElements) {
+          await announcement.play(ssml);
+        }
+        this.logSuccess('Headset device help spoken');
+      } catch (error) {
+        this.logError(`Failed to speak headset device help: ${error.message}`);
+      }
     },
 
 
@@ -841,10 +908,8 @@ const app = createApp({
     },
 
     collapseAll() {
-      for (const [id, component] of this.componentList) {
-        if (!this.isHeaderOnly(component)) {
-          this.collapsedComponents[id] = true;
-        }
+      for (const [id] of this.componentList) {
+        this.collapsedComponents[id] = true;
       }
       this.collapsedComponents = { ...this.collapsedComponents };
     },
@@ -1099,6 +1164,7 @@ const app = createApp({
 });
 
 app.component('toggle-switch', ToggleSwitch);
+app.component('help-tooltip', HelpTooltip);
 app.component('keypad-component', Keypad);
 app.component('headset-component', Headset);
 app.component('generic-component', GenericComponent);

--- a/docs/examples/tester.html
+++ b/docs/examples/tester.html
@@ -177,14 +177,14 @@
             </div>
             <div class="component-list">
               <div v-for="[id, component] in componentList" :key="id"
-                   class="component-item" :class="{ ready: component.ready, enabled: component.enabled, 'header-only': isHeaderOnly(component) || isCollapsed(id) }">
+                   class="component-item" :class="{ ready: component.ready, enabled: component.enabled, 'header-only': isCollapsed(id) }">
 
                 <!-- Title Row -->
                 <div class="component-title-row"
-                     :style="!isHeaderOnly(component) ? 'cursor: pointer' : ''"
-                     @click="!isHeaderOnly(component) && toggleCollapse(id)">
+                     style="cursor: pointer"
+                     @click="toggleCollapse(id)">
                   <div class="component-title-left">
-                    <span v-if="!isHeaderOnly(component)" class="collapse-chevron" :class="{ collapsed: isCollapsed(id) }">&#9660;</span>
+                    <span class="collapse-chevron" :class="{ collapsed: isCollapsed(id) }">&#9660;</span>
 
                     <div class="component-name"
                          @mouseenter="startCharHover($event, component)"


### PR DESCRIPTION
**Part of a 59-PR sequenced release across 15 repositories — do not merge in isolation.** Merge order, the package publishes that sit between repositories, and which failing checks are expected and what clears them are all in the [merge runbook](https://claude.ai/code/artifact/51daa277-8558-499d-ba17-3645101ca052). Find this PR's phase there before merging it.

---

**Targets `master` directly.** Merge position **7 of 7** in this repository's queue — the order matters, the base does not.

---

Adds tester-side UI for the CUSS2 ADA accessibility flow: the tester now exposes the Headset component, speaks device-help SSML on headset insertion, and surfaces the \`deviceHelpInstruction\` SSML as interactive tooltips for any assistive component.