### PR TITLE
feat(status): read component status from currentComponentState — 1.2.x maintenance (1.3.0-beta.0)

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,6 +1,6 @@
 {
   "name": "@cuss/cuss2-ts",
-  "version": "1.2.0",
+  "version": "1.3.0-beta.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "tasks": {

--- a/src/component-status-updates.test.ts
+++ b/src/component-status-updates.test.ts
@@ -287,3 +287,97 @@ Deno.test("Component status updates - multiple unsolicited messages should updat
   assertEquals(statusChangeSpy.calls[2].args[0], MessageCodes.OK);
   assertEquals(component.status, MessageCodes.OK);
 });
+
+// --- bridge2to1: status relocated to meta.currentComponentState.status --------------------------
+// The newer bridge pins meta.messageCode to "OK" and reports the real status in
+// meta.currentComponentState.status. cuss2-ts must read the status from there when that object is
+// present, and fall back to messageCode when it is not (legacy airport bridge). This is the exact
+// message shape captured from the new bridge for an out-of-paper bag tag printer.
+
+Deno.test("Component status (new bridge) - reads status from currentComponentState.status, ignoring messageCode=OK", () => {
+  const { cuss2 } = createMockCuss2();
+  const component = new BarcodeReader(mockDevice.createBarcodeReader(100), cuss2);
+  // @ts-ignore - seed initial status for the test
+  component._status = MessageCodes.OK;
+
+  const statusChangeSpy = spy();
+  component.on("statusChange", statusChangeSpy);
+
+  // New-bridge peripherals_query response: messageCode pinned "OK", real status MEDIA_EMPTY nested.
+  const newBridgeMsg = {
+    meta: {
+      currentApplicationState: { applicationStateCode: AppState.ACTIVE },
+      componentID: 100,
+      componentState: ComponentState.READY,
+      messageCode: MessageCodes.OK,
+      currentComponentState: { componentState: ComponentState.READY, status: MessageCodes.MEDIA_EMPTY, enabled: false },
+      platformDirective: PlatformDirectives.PERIPHERALS_QUERY,
+    },
+    payload: {},
+  } as unknown as PlatformData;
+
+  // The change must be DETECTED (messageCode/componentState are unchanged — only the nested status moved).
+  assertEquals(component.stateIsDifferent(newBridgeMsg), true);
+
+  component.updateState(newBridgeMsg);
+
+  assertEquals(component.status, MessageCodes.MEDIA_EMPTY);
+  assertEquals(statusChangeSpy.calls.length, 1);
+  assertEquals(statusChangeSpy.calls[0].args[0], MessageCodes.MEDIA_EMPTY);
+});
+
+Deno.test("Component status (new bridge) - currentComponentState wins even when messageCode disagrees", () => {
+  const { cuss2 } = createMockCuss2();
+  const component = new BarcodeReader(mockDevice.createBarcodeReader(100), cuss2);
+  // @ts-ignore - seed initial status for the test
+  component._status = MessageCodes.MEDIA_EMPTY;
+
+  const statusChangeSpy = spy();
+  component.on("statusChange", statusChangeSpy);
+
+  // messageCode says HARDWARE_ERROR but the authoritative nested status says OK (recovered) —
+  // currentComponentState.status must win when present.
+  component.updateState({
+    meta: {
+      currentApplicationState: { applicationStateCode: AppState.ACTIVE },
+      componentID: 100,
+      componentState: ComponentState.READY,
+      messageCode: MessageCodes.HARDWARE_ERROR,
+      currentComponentState: { componentState: ComponentState.READY, status: MessageCodes.OK, enabled: true },
+      platformDirective: PlatformDirectives.PERIPHERALS_QUERY,
+    },
+    payload: {},
+  } as unknown as PlatformData);
+
+  assertEquals(component.status, MessageCodes.OK);
+  assertEquals(statusChangeSpy.calls.length, 1);
+  assertEquals(statusChangeSpy.calls[0].args[0], MessageCodes.OK);
+});
+
+Deno.test("Component status (legacy bridge) - no currentComponentState falls back to messageCode", () => {
+  const { cuss2 } = createMockCuss2();
+  const component = new BarcodeReader(mockDevice.createBarcodeReader(100), cuss2);
+  // @ts-ignore - seed initial status for the test
+  component._status = MessageCodes.OK;
+
+  const statusChangeSpy = spy();
+  component.on("statusChange", statusChangeSpy);
+
+  // Legacy unsolicited message: status lives in messageCode, no currentComponentState object.
+  const legacyMsg = {
+    meta: {
+      currentApplicationState: { applicationStateCode: AppState.ACTIVE },
+      componentID: 100,
+      componentState: ComponentState.READY,
+      messageCode: MessageCodes.MEDIA_EMPTY,
+    },
+    payload: {},
+  } as unknown as PlatformData;
+
+  assertEquals(component.stateIsDifferent(legacyMsg), true);
+  component.updateState(legacyMsg);
+
+  assertEquals(component.status, MessageCodes.MEDIA_EMPTY);
+  assertEquals(statusChangeSpy.calls.length, 1);
+  assertEquals(statusChangeSpy.calls[0].args[0], MessageCodes.MEDIA_EMPTY);
+});

--- a/src/models/base/BaseComponent.ts
+++ b/src/models/base/BaseComponent.ts
@@ -18,6 +18,7 @@ import {
 } from "cuss2-typescript-models";
 import { DeviceType } from "../deviceType.ts";
 import type { ComponentAPI } from "../../cuss2/ComponentAPI.ts";
+import { resolveStatusCode } from "./componentUtils.ts";
 
 export abstract class BaseComponent extends EventEmitter {
   protected _component: EnvironmentComponent;
@@ -117,7 +118,11 @@ export abstract class BaseComponent extends EventEmitter {
   }
 
   stateIsDifferent(msg: PlatformData): boolean {
-    return this.status !== msg.meta.messageCode || this._componentState !== msg.meta.componentState;
+    // Compare against the RESOLVED status (currentComponentState.status on the new bridge, else
+    // messageCode). Using messageCode directly here would miss every out-of-media/fault transition
+    // on the new bridge, where messageCode is pinned to "OK" — the change would be dropped by the
+    // caller's `stateIsDifferent` gate before updateState ever runs.
+    return this.status !== resolveStatusCode(msg.meta) || this._componentState !== msg.meta.componentState;
   }
 
   updateState(msg: PlatformData): void {
@@ -146,9 +151,12 @@ export abstract class BaseComponent extends EventEmitter {
       !meta.platformDirective ||
       meta.platformDirective === PlatformDirectives.PERIPHERALS_QUERY
     ) {
-      // Handle message code (status) changes
-      if (meta?.messageCode !== undefined && this._status !== meta.messageCode) {
-        this._status = meta.messageCode as MessageCodes;
+      // Handle message code (status) changes. Source the status through resolveStatusCode so the new
+      // bridge's relocated `currentComponentState.status` is honored when present, with the legacy
+      // `meta.messageCode` as the fallback for the older bridge.
+      const statusCode = resolveStatusCode(meta);
+      if (statusCode !== undefined && this._status !== statusCode) {
+        this._status = statusCode as MessageCodes;
         this.emit("statusChange", this._status);
       }
     }

--- a/src/models/base/componentUtils.ts
+++ b/src/models/base/componentUtils.ts
@@ -9,9 +9,29 @@ import type {
   CommonUsePaymentMessage,
   DataRecordList,
   IlluminationData,
+  MessageCodes,
   PlatformData,
   ScreenResolution,
 } from "cuss2-typescript-models";
+import type { PlatformDataMetaWithCurrent } from "../../types/modelExtensions.ts";
+
+/**
+ * Resolve a component's authoritative status code from a platform message.
+ *
+ * The newer `bridge2to1` platform moved the live component status out of `meta.messageCode` (which
+ * it now pins to `"OK"`) and into `meta.currentComponentState.status`. When that object is present
+ * we trust it exclusively — `messageCode` is no longer meaningful there. When it is ABSENT (the
+ * legacy bridge still running at the airports) we fall back to `meta.messageCode`, so component
+ * status tracking is byte-for-byte unchanged against the old bridge and any other consumer.
+ *
+ * This is the single seam through which BOTH `stateIsDifferent` (change detection) and
+ * `updateState` (assignment) read status, so the two can never disagree about the source field.
+ */
+export function resolveStatusCode(meta: PlatformData["meta"]): MessageCodes | undefined {
+  const current = (meta as PlatformDataMetaWithCurrent).currentComponentState;
+  if (current) return current.status;
+  return meta.messageCode;
+}
 
 // Type for all possible send data types
 type SendDataTypes =

--- a/src/types/modelExtensions.ts
+++ b/src/types/modelExtensions.ts
@@ -7,6 +7,11 @@
 
 // Import the original enums
 import { ComponentTypes, CussDataTypes as _CussDataTypes, DeviceTypes, MediaTypes as _MediaTypes } from "cuss2-typescript-models";
+import type {
+  ComponentState as _ComponentState,
+  MessageCodes as _MessageCodes,
+  PlatformData as _PlatformData,
+} from "cuss2-typescript-models";
 
 // Re-export other imports
 export type {
@@ -28,3 +33,23 @@ export type CussDataTypes = _CussDataTypes | string;
 // Re-export the enum values under the same name using namespace merging
 export const MediaTypes = _MediaTypes;
 export const CussDataTypes = _CussDataTypes;
+
+/**
+ * Nested component-state object the newer `bridge2to1` platform sends on `meta`.
+ *
+ * That bridge relocated a component's LIVE status out of `meta.messageCode` (which it now pins to
+ * `"OK"`) into here — `currentComponentState.status` is the real code (e.g. `MEDIA_EMPTY`). The
+ * legacy bridge still deployed at the airports does NOT send this object, so its mere PRESENCE is
+ * the signal that the status has moved. It is not part of `cuss2-typescript-models@2.0.1`, so it is
+ * declared here rather than bumping the pinned models package.
+ */
+export interface CurrentComponentState {
+  componentState?: _ComponentState;
+  status?: _MessageCodes;
+  enabled?: boolean;
+}
+
+/** `PlatformData["meta"]` widened with the optional `currentComponentState` the new bridge adds. */
+export type PlatformDataMetaWithCurrent = _PlatformData["meta"] & {
+  currentComponentState?: CurrentComponentState;
+};


### PR DESCRIPTION
## Target: the `1.2.x` maintenance line — NOT `master`

`master` is on the current line (1.5.0) and depends on platform behavior the **older bridge deployed at the airports cannot support**. This change must ship to kiosks running that older bridge, so it is a minimal, backward-compatible patch **on top of tag `v1.2.0`**, not an upgrade.

- Base branch: **`release/1.2.x`** (branched from tag `v1.2.0`).
- Diff: a single commit on top of `v1.2.0` — nothing from the 1.4.x/1.5.x line is involved.
- This does **not** merge into `master`.

## Why

The newer **bridge2to1** platform changed where a component's live status is reported. It no longer carries the real status in `meta.messageCode` — that field is now pinned to `"OK"` — and instead reports it in a new nested object, `meta.currentComponentState.status`.

Captured message from the new bridge for an **out-of-paper bag tag printer**:

```jsonc
"meta": {
  "componentID": 8,
  "componentState": "READY",
  "currentComponentState": { "componentState": "READY", "status": "MEDIA_EMPTY", "enabled": false },
  "messageCode": "OK",                 // <-- pinned to OK on the new bridge
  "platformDirective": "peripherals_query"
}
```

v1.2.0 derives `component.status` from `meta.messageCode`, so against this bridge the failure is invisible in two compounding ways:

1. `updateState()` sets `_status = meta.messageCode = "OK"`, so a component that is actually out of media / faulted reports healthy.
2. `stateIsDifferent()` also compares against `meta.messageCode`. Since `messageCode` stays `"OK"` and `componentState` stays `READY`, it returns `false` — so `updateState` never runs and **`componentStateChange` is never emitted at all**. The transition is dropped before any consumer can see it.

Downstream this is what causes **out-of-paper printers to stay in service at the airports**: the app reads `component.status`/`feeder.status`, never sees `MEDIA_EMPTY`, and keeps the kiosk available.

## What

Introduce a single `resolveStatusCode(meta)` seam:

- When `meta.currentComponentState` is **present**, trust `currentComponentState.status` (the new bridge; `messageCode` is no longer meaningful there).
- When it is **absent**, fall back to `meta.messageCode` (legacy bridge / any other consumer) — byte-for-byte unchanged behavior.

Both `stateIsDifferent` (change detection) and `updateState` (assignment) route through this one function, so they can never disagree about which field the status comes from. Because the resolution lives in `BaseComponent`, every component type (printers, feeders, readers) picks it up with no per-component edits. Scope is deliberately limited to this status field only.

## Changes

- `src/models/base/componentUtils.ts` — add `resolveStatusCode(meta)`.
- `src/models/base/BaseComponent.ts` — use it in `stateIsDifferent` and `updateState`.
- `src/types/modelExtensions.ts` — declare `CurrentComponentState` + `PlatformDataMetaWithCurrent` (the field is not in the pinned `cuss2-typescript-models@2.0.1`, so it is typed here rather than bumping the models package).
- `src/component-status-updates.test.ts` — new cases: new-bridge relocation, `currentComponentState` wins over a disagreeing `messageCode`, and legacy `messageCode` fallback.
- `deno.jsonc` — version `1.2.0` → `1.3.0-beta.0`.

## Compatibility & versioning

- Runs unchanged against the **old bridge** (no `currentComponentState` → `messageCode` path), and correctly against the **new bridge** — one build serves both.
- Ships as a **prerelease** on the 1.2.x line, `1.3.0-beta.0`, forked from `v1.2.0` (it is intentionally **not** an ancestor of `master`'s 1.4.x/1.5.x). The prerelease tag means `~1.2.0` / `^1.2.0` ranges do not resolve to it, so existing consumers won't pull it by accident; the airport kiosks on `1.2.0` are unaffected until a consumer explicitly opts in to the beta.

## Verification

- `deno check mod.ts` — clean
- `deno task test` — 242 passed, 0 failed
- `deno lint` / `deno fmt --check` on changed files — clean