### PR TITLE
chore(status): remove comments introduced by #67

### DIFF
--- a/src/component-status-updates.test.ts
+++ b/src/component-status-updates.test.ts
@@ -288,22 +288,15 @@ Deno.test("Component status updates - multiple unsolicited messages should updat
   assertEquals(component.status, MessageCodes.OK);
 });
 
-// --- bridge2to1: status relocated to meta.currentComponentState.status --------------------------
-// The newer bridge pins meta.messageCode to "OK" and reports the real status in
-// meta.currentComponentState.status. cuss2-ts must read the status from there when that object is
-// present, and fall back to messageCode when it is not (legacy airport bridge). This is the exact
-// message shape captured from the new bridge for an out-of-paper bag tag printer.
-
 Deno.test("Component status (new bridge) - reads status from currentComponentState.status, ignoring messageCode=OK", () => {
   const { cuss2 } = createMockCuss2();
   const component = new BarcodeReader(mockDevice.createBarcodeReader(100), cuss2);
-  // @ts-ignore - seed initial status for the test
+  // @ts-ignore
   component._status = MessageCodes.OK;
 
   const statusChangeSpy = spy();
   component.on("statusChange", statusChangeSpy);
 
-  // New-bridge peripherals_query response: messageCode pinned "OK", real status MEDIA_EMPTY nested.
   const newBridgeMsg = {
     meta: {
       currentApplicationState: { applicationStateCode: AppState.ACTIVE },
@@ -316,7 +309,6 @@ Deno.test("Component status (new bridge) - reads status from currentComponentSta
     payload: {},
   } as unknown as PlatformData;
 
-  // The change must be DETECTED (messageCode/componentState are unchanged — only the nested status moved).
   assertEquals(component.stateIsDifferent(newBridgeMsg), true);
 
   component.updateState(newBridgeMsg);
@@ -329,14 +321,12 @@ Deno.test("Component status (new bridge) - reads status from currentComponentSta
 Deno.test("Component status (new bridge) - currentComponentState wins even when messageCode disagrees", () => {
   const { cuss2 } = createMockCuss2();
   const component = new BarcodeReader(mockDevice.createBarcodeReader(100), cuss2);
-  // @ts-ignore - seed initial status for the test
+  // @ts-ignore
   component._status = MessageCodes.MEDIA_EMPTY;
 
   const statusChangeSpy = spy();
   component.on("statusChange", statusChangeSpy);
 
-  // messageCode says HARDWARE_ERROR but the authoritative nested status says OK (recovered) —
-  // currentComponentState.status must win when present.
   component.updateState({
     meta: {
       currentApplicationState: { applicationStateCode: AppState.ACTIVE },
@@ -357,13 +347,12 @@ Deno.test("Component status (new bridge) - currentComponentState wins even when 
 Deno.test("Component status (legacy bridge) - no currentComponentState falls back to messageCode", () => {
   const { cuss2 } = createMockCuss2();
   const component = new BarcodeReader(mockDevice.createBarcodeReader(100), cuss2);
-  // @ts-ignore - seed initial status for the test
+  // @ts-ignore
   component._status = MessageCodes.OK;
 
   const statusChangeSpy = spy();
   component.on("statusChange", statusChangeSpy);
 
-  // Legacy unsolicited message: status lives in messageCode, no currentComponentState object.
   const legacyMsg = {
     meta: {
       currentApplicationState: { applicationStateCode: AppState.ACTIVE },

--- a/src/models/base/BaseComponent.ts
+++ b/src/models/base/BaseComponent.ts
@@ -118,10 +118,6 @@ export abstract class BaseComponent extends EventEmitter {
   }
 
   stateIsDifferent(msg: PlatformData): boolean {
-    // Compare against the RESOLVED status (currentComponentState.status on the new bridge, else
-    // messageCode). Using messageCode directly here would miss every out-of-media/fault transition
-    // on the new bridge, where messageCode is pinned to "OK" — the change would be dropped by the
-    // caller's `stateIsDifferent` gate before updateState ever runs.
     return this.status !== resolveStatusCode(msg.meta) || this._componentState !== msg.meta.componentState;
   }
 
@@ -151,9 +147,7 @@ export abstract class BaseComponent extends EventEmitter {
       !meta.platformDirective ||
       meta.platformDirective === PlatformDirectives.PERIPHERALS_QUERY
     ) {
-      // Handle message code (status) changes. Source the status through resolveStatusCode so the new
-      // bridge's relocated `currentComponentState.status` is honored when present, with the legacy
-      // `meta.messageCode` as the fallback for the older bridge.
+      // Handle message code (status) changes
       const statusCode = resolveStatusCode(meta);
       if (statusCode !== undefined && this._status !== statusCode) {
         this._status = statusCode as MessageCodes;

--- a/src/models/base/componentUtils.ts
+++ b/src/models/base/componentUtils.ts
@@ -15,18 +15,6 @@ import type {
 } from "cuss2-typescript-models";
 import type { PlatformDataMetaWithCurrent } from "../../types/modelExtensions.ts";
 
-/**
- * Resolve a component's authoritative status code from a platform message.
- *
- * The newer `bridge2to1` platform moved the live component status out of `meta.messageCode` (which
- * it now pins to `"OK"`) and into `meta.currentComponentState.status`. When that object is present
- * we trust it exclusively — `messageCode` is no longer meaningful there. When it is ABSENT (the
- * legacy bridge still running at the airports) we fall back to `meta.messageCode`, so component
- * status tracking is byte-for-byte unchanged against the old bridge and any other consumer.
- *
- * This is the single seam through which BOTH `stateIsDifferent` (change detection) and
- * `updateState` (assignment) read status, so the two can never disagree about the source field.
- */
 export function resolveStatusCode(meta: PlatformData["meta"]): MessageCodes | undefined {
   const current = (meta as PlatformDataMetaWithCurrent).currentComponentState;
   if (current) return current.status;

--- a/src/types/modelExtensions.ts
+++ b/src/types/modelExtensions.ts
@@ -34,22 +34,12 @@ export type CussDataTypes = _CussDataTypes | string;
 export const MediaTypes = _MediaTypes;
 export const CussDataTypes = _CussDataTypes;
 
-/**
- * Nested component-state object the newer `bridge2to1` platform sends on `meta`.
- *
- * That bridge relocated a component's LIVE status out of `meta.messageCode` (which it now pins to
- * `"OK"`) into here — `currentComponentState.status` is the real code (e.g. `MEDIA_EMPTY`). The
- * legacy bridge still deployed at the airports does NOT send this object, so its mere PRESENCE is
- * the signal that the status has moved. It is not part of `cuss2-typescript-models@2.0.1`, so it is
- * declared here rather than bumping the pinned models package.
- */
 export interface CurrentComponentState {
   componentState?: _ComponentState;
   status?: _MessageCodes;
   enabled?: boolean;
 }
 
-/** `PlatformData["meta"]` widened with the optional `currentComponentState` the new bridge adds. */
 export type PlatformDataMetaWithCurrent = _PlatformData["meta"] & {
   currentComponentState?: CurrentComponentState;
 };


### PR DESCRIPTION
Follow-up to #67 (already merged into `release/1.2.x`, so it can't be reopened).

Applies the review feedback: remove the explanatory comments introduced with the `currentComponentState` status change.

- `src/models/base/componentUtils.ts` — drop the `resolveStatusCode()` JSDoc block.
- `src/models/base/BaseComponent.ts` — drop the two inline blocks; restore the original one-line `// Handle message code (status) changes`.
- `src/types/modelExtensions.ts` — drop the `CurrentComponentState` / `PlatformDataMetaWithCurrent` doc comments.
- `src/component-status-updates.test.ts` — drop the section header and inline comments; keep the functional `@ts-ignore` directives (prose trimmed).

No behavior change. `deno check`, `deno fmt --check`, and 242 tests all pass.